### PR TITLE
fix: do not create identities table, create trigger if it already exists

### DIFF
--- a/views/001_roles.sql
+++ b/views/001_roles.sql
@@ -1,5 +1,4 @@
-DO
-$$
+DO $$
 BEGIN
     IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'postgrest_api') THEN
         CREATE ROLE postgrest_api;
@@ -10,5 +9,4 @@ BEGIN
     IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'postgrest_anon') THEN
         CREATE ROLE postgrest_anon;
     END IF;
-END
-$$;
+END $$;

--- a/views/002_seed.sql
+++ b/views/002_seed.sql
@@ -1,24 +1,19 @@
-DO
-$$
+DO $$
 BEGIN
-   IF NOT EXISTS (SELECT FROM people) THEN
-      INSERT INTO people (name) VALUES ('System');
-   END IF;
-END
-$$;
+    IF NOT EXISTS (SELECT FROM people WHERE name = 'System') THEN
+        INSERT INTO people (name) VALUES ('System');
+    END IF;
+END $$;
 
-DO
-$$
+DO $$
 BEGIN
-   IF NOT EXISTS (
-      SELECT FROM severities ) THEN
-INSERT INTO severities (id, name, icon, aliases)
-   VALUES (1, 'Critical', 'error',ARRAY ['P1']),
-          (2, 'Blocker', 'error', ARRAY['P2']),
-          (3, 'High', 'warning',ARRAY ['P3']),
-          (4, 'Medium', 'info',ARRAY ['P4']),
-          (5, 'Low', 'info', ARRAY['P4']);
+   IF NOT EXISTS (SELECT FROM severities ) THEN
+        INSERT INTO severities (id, name, icon, aliases)
+        VALUES
+            (1, 'Critical', 'error',ARRAY ['P1']),
+            (2, 'Blocker', 'error', ARRAY['P2']),
+            (3, 'High', 'warning',ARRAY ['P3']),
+            (4, 'Medium', 'info',ARRAY ['P4']),
+            (5, 'Low', 'info', ARRAY['P4']);
    END IF;
-END
-$$;
-
+END $$;

--- a/views/011_users.sql
+++ b/views/011_users.sql
@@ -1,19 +1,20 @@
-CREATE TABLE IF NOT EXISTS identities();
-
 -- Insert identities in people table
 CREATE OR REPLACE FUNCTION insert_identity_to_people()
 RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO people(id, name, email)
+    INSERT INTO people (id, name, email)
     VALUES (NEW.id, concat(NEW.traits::json->'name'->>'first', ' ', NEW.traits::json->'name'->>'last'), NEW.traits::json->>'email');
     RETURN NEW;
 END
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER identity_to_people
-    AFTER INSERT
-    ON identities
-    FOR EACH ROW
-    EXECUTE PROCEDURE insert_identity_to_people();
-
-
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'identities') THEN
+        CREATE OR REPLACE TRIGGER identity_to_people
+            AFTER INSERT
+            ON identities
+            FOR EACH ROW
+            EXECUTE PROCEDURE insert_identity_to_people();
+    END IF;
+END $$;


### PR DESCRIPTION
This fixes a race condition where kratos migration failed since identities table was already created by us