### PR TITLE
feat: add generic gorm scan/value funcs

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -371,7 +371,7 @@ func GenericStructValue[T any](t T, defaultNull bool) (driver.Value, error) {
 // GenericStructScan can be set as the Scan(val) func for any json struct
 func GenericStructScan[T any](t *T, val any) error {
 	if val == nil {
-		*t = *new(T)
+		t = new(T)
 		return nil
 	}
 	var ba []byte
@@ -381,7 +381,7 @@ func GenericStructScan[T any](t *T, val any) error {
 	case string:
 		ba = []byte(v)
 	default:
-		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", val))
+		return fmt.Errorf("Failed to unmarshal JSONB value: %v", val)
 	}
 	err := json.Unmarshal(ba, &t)
 	return err


### PR DESCRIPTION
With this we can avoid a lot of boilerplate code when working with json based structs with gorm. We wouldn't have to write Scan/Value() funcs everytime.

```go
type Person struct {
	ID         uuid.UUID        `json:"id" gorm:"default:generate_ulid()"`
	Name       string           `json:"name,omitempty"`
	Properties PersonProperties `json:"properties,omitempty"`
}

type PersonProperties struct {
	Car   string `json:"car,omitempty"`
	Wheel string `json:"wheel,omitempty"`
}

func (p PersonProperties) Value() (driver.Value, error) {
	return types.GenericStructValue(p, true)
}

func (p *PersonProperties) Scan(val any) error {
	return types.GenericStructScan(&p, val)
}
```