### PR TITLE
Agents and connections

### DIFF
--- a/schema/agents.hcl
+++ b/schema/agents.hcl
@@ -1,0 +1,87 @@
+
+table "agents" {
+  schema = schema.public
+  column "id" {
+    null    = false
+    type    = uuid
+    default = sql("generate_ulid()")
+  }
+
+  column "name" {
+    null = false
+    type = text
+  }
+
+  column "hostname" {
+    null = true
+    type = text
+  }
+
+  column "description" {
+    null = true
+    type = text
+  }
+
+  column "ip" {
+    null = true
+    type = text
+  }
+
+  column "version" {
+    null = true
+    type = text
+  }
+
+  column "username" {
+    null = true
+    type = text
+  }
+
+  column "person_id" {
+    null = true
+    type = uuid
+  }
+
+  column "properties" {
+    null = true
+    type = jsonb
+  }
+
+  column "tls" {
+    null = true
+    type = text
+  }
+
+  column "created_by" {
+    null = true
+    type = uuid
+  }
+
+  column "created_at" {
+    null    = false
+    type    = timestamp
+    default = sql("now()")
+  }
+
+  column "updated_at" {
+    null    = false
+    type    = timestamp
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  index "agents_name_hostname_key" {
+    unique  = true
+    columns = [column.name, column.hostname]
+  }
+
+  foreign_key "agents_created_by_fkey" {
+    columns     = [column.created_by]
+    ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+}

--- a/schema/checks.hcl
+++ b/schema/checks.hcl
@@ -130,6 +130,11 @@ table "checks" {
     null = false
     type = uuid
   }
+  column "connection_id" {
+    null    = true
+    type    = uuid
+    comment = "The connection used to run the health check"
+  }
   column "type" {
     null = false
     type = text
@@ -196,6 +201,12 @@ table "checks" {
   }
   primary_key {
     columns = [column.id]
+  }
+  foreign_key "checks_connection_id_fkey" {
+    columns     = [column.created_by]
+    ref_columns = [table.connections.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
   }
   foreign_key "checks_canary_id_fkey" {
     columns     = [column.canary_id]

--- a/schema/checks.hcl
+++ b/schema/checks.hcl
@@ -5,6 +5,10 @@ table "canaries" {
     type    = uuid
     default = sql("generate_ulid()")
   }
+  column "agent_id" {
+    null = true
+    type = uuid
+  }
   column "name" {
     null = false
     type = text
@@ -47,6 +51,12 @@ table "canaries" {
   }
   primary_key {
     columns = [column.id]
+  }
+  foreign_key "canaries_agent_id_fkey" {
+    columns     = [column.agent_id]
+    ref_columns = [table.agents.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
   }
   foreign_key "canaries_created_by_fkey" {
     columns     = [column.created_by]

--- a/schema/components.hcl
+++ b/schema/components.hcl
@@ -10,6 +10,11 @@ table "templates" {
     null = false
     type = text
   }
+  column "connection_id" {
+    null    = true
+    type    = uuid
+    comment = "The connection used to create the topology, if more than 1 topology is defined in the spec, they will all use the same connection. If you need to use multiple connections, create multiple topologies and use selection rules to create the desired topology."
+  }
   column "namespace" {
     null = false
     type = text
@@ -48,6 +53,12 @@ table "templates" {
   foreign_key "templates_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  foreign_key "templates_connection_id_fkey" {
+    columns     = [column.connection_id]
+    ref_columns = [table.connections.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }

--- a/schema/components.hcl
+++ b/schema/components.hcl
@@ -114,6 +114,10 @@ table "components" {
     type    = uuid
     default = sql("generate_ulid()")
   }
+  column "agent_id" {
+    null = true
+    type = uuid
+  }
   column "system_template_id" {
     null = true
     type = uuid
@@ -276,6 +280,13 @@ table "components" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  foreign_key "components_agent_id_fkey" {
+    columns     = [column.agent_id]
+    ref_columns = [table.agents.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+
   index "components_system_template_id_type_name_parent_id_key" {
     unique  = true
     columns = [column.system_template_id, column.type, column.name, column.parent_id]

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -362,12 +362,24 @@ table "config_scrapers" {
     type    = timestamp
     default = sql("now()")
   }
+  column "connection_id" {
+    null    = true
+    type    = uuid
+    comment = "The connection used to run the scraper, if more than 1 scraper is defined in the spec, they will all use the same connection."
+  }
   primary_key {
     columns = [column.id]
   }
   foreign_key "config_scrapers_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+
+  foreign_key "config_scrapers_connection_id_fkey" {
+    columns     = [column.created_by]
+    ref_columns = [table.connections.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -331,8 +331,7 @@ table "config_scrapers" {
     null = true
     type = text
   }
-  column "scraper_type" {
-    null = false
+  column "name" {
     type = text
   }
   column "spec" {

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -143,6 +143,10 @@ table "config_items" {
     type    = uuid
     default = sql("generate_ulid()")
   }
+  column "agent_id" {
+    null = true
+    type = uuid
+  }
   column "icon" {
     null = true
     type = text
@@ -261,6 +265,12 @@ table "config_items" {
   foreign_key "config_items_scraper_id_fkey" {
     columns     = [column.scraper_id]
     ref_columns = [table.config_scrapers.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  foreign_key "config_items_agent_id_fkey" {
+    columns     = [column.agent_id]
+    ref_columns = [table.agents.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }

--- a/schema/connections.hcl
+++ b/schema/connections.hcl
@@ -1,0 +1,72 @@
+table "connections" {
+  schema = schema.public
+  column "id" {
+    null    = false
+    type    = uuid
+    default = sql("generate_ulid()")
+  }
+  column "name" {
+    null = false
+    type = text
+  }
+  column "type" {
+    null    = false
+    type    = text
+    comment = "The type of connection e.g. postgres, mysql, aws, gcp, http etc."
+  }
+  column "url" {
+    null    = true
+    type    = text
+    comment = "A raw value or encrypted value prefixed with 'enc:' or a configmap key in the format 'config:namespace/name/key' or secret in the format 'secret:namespace/name/key', the url can include $(password) and $(username) which will be replaced with the password and username respectively."
+  }
+  column "username" {
+    null    = true
+    type    = text
+    comment = "A raw value or encrypted value prefixed with 'enc:' or a configmap key in the format 'config:namespace/name/key' or secret in the format 'secret:namespace/name/key'"
+  }
+  column "password" {
+    null    = true
+    type    = text
+    comment = "A raw value or encrypted value prefixed with 'enc:' or a configmap key in the format 'config:namespace/name/key' or secret in the format 'secret:namespace/name/key'"
+  }
+  column "certificate" {
+    null = true
+    type = text
+
+  }
+  column "properties" {
+    null    = true
+    type    = jsonb
+    comment = "Used for storing connection properties e.g. region and STS endpoint for AWS connections."
+  }
+  column "insecure_tls" {
+    null    = true
+    type    = boolean
+    default = true
+  }
+  column "created_by" {
+    null = true
+    type = uuid
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamp
+    default = sql("now()")
+  }
+
+  column "updated_at" {
+    null    = false
+    type    = timestamp
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "connections_created_by_fkey" {
+    columns     = [column.created_by]
+    ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+}


### PR DESCRIPTION
Agents are meant to represent push clients - we might need to update some of the constraints lookups to use it
Connections are for re-using credentials without needing access / exposing them