### PR TITLE
feat: add scraper id to config analysis

### DIFF
--- a/fixtures/dummy/config_analysis.go
+++ b/fixtures/dummy/config_analysis.go
@@ -16,6 +16,7 @@ var LogisticsDBRDSAnalysis = models.ConfigAnalysis{
 	Severity:      "critical",
 	Message:       "Port exposed to public",
 	FirstObserved: &currentTime,
+	Status:        models.AnalysisStatusOpen,
 }
 
 var EC2InstanceBAnalysis = models.ConfigAnalysis{
@@ -25,6 +26,7 @@ var EC2InstanceBAnalysis = models.ConfigAnalysis{
 	Severity:      "critical",
 	Message:       "SSH key not rotated",
 	FirstObserved: &currentTime,
+	Status:        models.AnalysisStatusOpen,
 }
 
 var AllDummyConfigAnalysis = []models.ConfigAnalysis{

--- a/models/config.go
+++ b/models/config.go
@@ -25,6 +25,13 @@ const (
 	ConfigClassVirtualMachine = "VirtualMachine"
 )
 
+// Config Analysis statuses
+const (
+	AnalysisStatusOpen     = "open"
+	AnalysisStatusResolved = "resolved"
+	AnalysisStatusSilenced = "silenced"
+)
+
 // ConfigItem represents the config item database table
 type ConfigItem struct {
 	ID            uuid.UUID            `json:"id" faker:"uuid_hyphenated"`
@@ -166,6 +173,7 @@ type ConfigAnalysis struct {
 	ExternalID    string        `gorm:"-"`
 	ConfigType    string        `gorm:"-"`
 	ConfigID      uuid.UUID     `gorm:"column:config_id;default:''" json:"config_id"`
+	ScraperID     *uuid.UUID    `gorm:"column:scraper_id;default:null" json:"scraper_id"`
 	Analyzer      string        `gorm:"column:analyzer" json:"analyzer" faker:"oneof: ec2-instance-no-public-ip, eks-endpoint-no-public-access"`
 	Message       string        `gorm:"column:message" json:"message"`
 	Summary       string        `gorm:"column:summary;default:null" json:"summary,omitempty"`

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -9,6 +9,10 @@ table "config_analysis" {
     null = false
     type = uuid
   }
+  column "scraper_id" {
+    null = true
+    type = uuid
+  }
   column "created_by" {
     null = true
     type = uuid

--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -28,6 +28,7 @@ CREATE or REPLACE VIEW configs AS
       SELECT config_id,
         json_agg(json_build_object('analyzer',analyzer,'analysis_type',analysis_type,'severity',severity)) as analysis
       FROM config_analysis
+      WHERE config_analysis.status = 'open'
       GROUP BY  config_id
     ) as ca on ca.config_id = ci.id
     full join (
@@ -208,6 +209,7 @@ CREATE VIEW config_summary AS
     FROM
       config_analysis
       LEFT JOIN config_items ON config_items.id = config_analysis.config_id
+    WHERE config_analysis.status = 'open'
     GROUP BY
       config_items.type,
       config_analysis.analysis_type
@@ -262,7 +264,10 @@ CREATE VIEW config_class_summary AS
       COUNT(*) AS count
     FROM
       config_analysis
-      LEFT JOIN config_items ON config_items.id = config_analysis.config_id
+      LEFT JOIN config_items 
+    ON config_items.id = config_analysis.config_id
+    WHERE
+      config_analysis.status = 'open'
     GROUP BY
       config_items.config_class,
       config_analysis.analysis_type
@@ -298,4 +303,4 @@ CREATE VIEW config_class_summary AS
 
 DROP VIEW IF EXISTS config_analysis_analyzers;
 CREATE OR REPLACE VIEW config_analysis_analyzers AS
-  SELECT DISTINCT(analyzer) FROM config_analysis;
+  SELECT DISTINCT(analyzer) FROM config_analysis WHERE status = 'open';


### PR DESCRIPTION
* The default queries using config analysis filters only open analyses