### PR TITLE
fix: return only one component when id is provided in topology

### DIFF
--- a/topology.go
+++ b/topology.go
@@ -224,9 +224,21 @@ func createComponentTree(params TopologyOptions, components models.Components) [
 	}
 
 	tree := generateTree(components, compChildrenMap)
+
 	var root models.Components
 	for _, c := range tree {
-		if c.ParentId == nil || params.ID == c.ID.String() {
+		// If ID is provided, we solely use that in our root tree
+		if params.ID != "" {
+			if params.ID == c.ID.String() {
+				root = append(root, c)
+				break
+			}
+			continue
+		}
+
+		// In case of generic topology
+		// components without a parent will be in root
+		if c.ParentId == nil {
 			root = append(root, c)
 		}
 	}

--- a/topology_test.go
+++ b/topology_test.go
@@ -39,7 +39,7 @@ func testTopologyJSON(opts TopologyOptions, path string) {
 
 	expected := readTestFile(path)
 
-	jqExpr := `del(.. | .created_at?, .updated_at?, .children?, .parents?)`
+	jqExpr := `del(.. | .created_at?, .updated_at?)`
 	matchJSON([]byte(expected), treeJSON, &jqExpr)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/997