### PR TITLE
fix: set default event priority to high to prevent starvation

### DIFF
--- a/schema/system.hcl
+++ b/schema/system.hcl
@@ -34,7 +34,7 @@ table "event_queue" {
   column "priority" {
     null    = false
     type    = integer
-    default = 0
+    default = 100
   }
   primary_key {
     columns = [column.id]


### PR DESCRIPTION
Since default priority was 0, all the responder/notification and team events were getting starved

We not set lower priority explicitly for upstream push and by default events will have a higher priority than those