### PR TITLE
feat: add upstream and reconcile logic from incident commander

### DIFF
--- a/models/checks.go
+++ b/models/checks.go
@@ -111,10 +111,10 @@ func (u Uptime) String() string {
 }
 
 type CheckStatus struct {
-	CheckID   uuid.UUID `json:"check_id"`
+	CheckID   uuid.UUID `json:"check_id" gorm:"primaryKey"`
 	Status    bool      `json:"status"`
 	Invalid   bool      `json:"invalid,omitempty"`
-	Time      string    `json:"time"`
+	Time      string    `json:"time" gorm:"primaryKey"`
 	Duration  int       `json:"duration"`
 	Message   string    `json:"message,omitempty"`
 	Error     string    `json:"error,omitempty"`

--- a/upstream/reconcile.go
+++ b/upstream/reconcile.go
@@ -39,10 +39,6 @@ func NewUpstreamSyncer(upstreamConf UpstreamConfig, pageSize int) *upstreamSynce
 	}
 }
 
-func (t *upstreamSyncer) SetPagesize(size int) {
-	t.pageSize = size
-}
-
 func (t *upstreamSyncer) SyncTableWithUpstream(ctx dbContext, table string) error {
 	logger.Infof("Syncing table %q with upstream", table)
 

--- a/upstream/reconcile.go
+++ b/upstream/reconcile.go
@@ -1,0 +1,169 @@
+package upstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/flanksource/commons/logger"
+	"github.com/google/uuid"
+)
+
+type PaginateRequest struct {
+	Table string    `query:"table"`
+	From  uuid.UUID `query:"from"`
+	Size  int       `query:"size"`
+}
+
+type PaginateResponse struct {
+	Hash  string    `gorm:"column:sha256sum"`
+	Next  uuid.UUID `gorm:"column:last_id"`
+	Total int       `gorm:"column:total"`
+}
+
+type upstreamSyncer struct {
+	upstreamConf UpstreamConfig
+
+	// the max number of resources the agent fetches
+	// from the upstream in one request.
+	pageSize int
+}
+
+func NewUpstreamSyncer(upstreamConf UpstreamConfig, pageSize int) *upstreamSyncer {
+	return &upstreamSyncer{
+		upstreamConf: upstreamConf,
+		pageSize:     pageSize,
+	}
+}
+
+func (t *upstreamSyncer) SetPagesize(size int) {
+	t.pageSize = size
+}
+
+func (t *upstreamSyncer) SyncTableWithUpstream(ctx dbContext, table string) error {
+	logger.Infof("Syncing table %q with upstream", table)
+
+	var next uuid.UUID
+	for {
+		paginateRequest := PaginateRequest{From: next, Table: table, Size: t.pageSize}
+
+		current, err := GetIDsHash(ctx, table, next, t.pageSize)
+		if err != nil {
+			return fmt.Errorf("failed to fetch local id hash: %w", err)
+		}
+		next = current.Next
+
+		if current.Total == 0 {
+			break
+		}
+
+		upstreamStatus, err := t.fetchUpstreamStatus(ctx, paginateRequest)
+		if err != nil {
+			return fmt.Errorf("failed to fetch upstream status: %w", err)
+		}
+
+		if upstreamStatus.Hash == current.Hash {
+			continue
+		}
+
+		resp, err := t.fetchUpstreamResourceIDs(ctx, paginateRequest)
+		if err != nil {
+			return fmt.Errorf("failed to fetch upstream resource ids: %w", err)
+		}
+
+		pushData, err := GetMissingResourceIDs(ctx, resp, paginateRequest)
+		if err != nil {
+			return fmt.Errorf("failed to fetch missing resource ids: %w", err)
+		}
+
+		pushData.AgentName = t.upstreamConf.AgentName
+		if err := Push(ctx, t.upstreamConf, pushData); err != nil {
+			return fmt.Errorf("failed to push missing resource ids: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// fetchUpstreamResourceIDs requests all the existing resource ids from the upstream
+// that were sent by this agent.
+func (t *upstreamSyncer) fetchUpstreamResourceIDs(ctx dbContext, request PaginateRequest) ([]string, error) {
+	endpoint, err := url.JoinPath(t.upstreamConf.Host, "upstream", "pull", t.upstreamConf.AgentName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating url endpoint for host %s: %w", t.upstreamConf.Host, err)
+	}
+
+	req, err := t.createPaginateRequest(ctx, endpoint, request)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest: %w", err)
+	}
+
+	httpClient := http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("upstream server returned error status[%d]: %s", resp.StatusCode, string(respBody))
+	}
+
+	var response []string
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (t *upstreamSyncer) fetchUpstreamStatus(ctx context.Context, request PaginateRequest) (*PaginateResponse, error) {
+	endpoint, err := url.JoinPath(t.upstreamConf.Host, "upstream", "status", t.upstreamConf.AgentName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating url endpoint for host %s: %w", t.upstreamConf.Host, err)
+	}
+
+	req, err := t.createPaginateRequest(ctx, endpoint, request)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest: %w", err)
+	}
+
+	httpClient := http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("upstream server returned error status[%d]: %s", resp.StatusCode, string(respBody))
+	}
+
+	var response PaginateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (t *upstreamSyncer) createPaginateRequest(ctx context.Context, url string, request PaginateRequest) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest: %w", err)
+	}
+
+	query := req.URL.Query()
+	query.Add("table", request.Table)
+	query.Add("from", request.From.String())
+	query.Add("size", fmt.Sprintf("%d", request.Size))
+	req.URL.RawQuery = query.Encode()
+
+	req.SetBasicAuth(t.upstreamConf.Username, t.upstreamConf.Password)
+	return req, nil
+}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1,0 +1,220 @@
+package upstream
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/flanksource/commons/collections"
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type dbContext interface {
+	context.Context
+	DB() *gorm.DB
+}
+
+type UpstreamConfig struct {
+	AgentName string
+	Host      string
+	Username  string
+	Password  string
+	Labels    []string
+}
+
+func (t *UpstreamConfig) Valid() bool {
+	return t.Host != "" && t.Username != "" && t.Password != "" && t.AgentName != ""
+}
+
+func (t *UpstreamConfig) IsPartiallyFilled() bool {
+	return !t.Valid() && (t.Host != "" || t.Username != "" || t.Password != "" || t.AgentName != "")
+}
+
+func (t *UpstreamConfig) LabelsMap() map[string]string {
+	return collections.KeyValueSliceToMap(t.Labels)
+}
+
+// PushData consists of data about changes to
+// components, configs, analysis.
+type PushData struct {
+	AgentName                    string                               `json:"cluster_name,omitempty"`
+	Canaries                     []models.Canary                      `json:"canaries,omitempty"`
+	Checks                       []models.Check                       `json:"checks,omitempty"`
+	Components                   []models.Component                   `json:"components,omitempty"`
+	ConfigScrapers               []models.ConfigScraper               `json:"config_scrapers,omitempty"`
+	ConfigAnalysis               []models.ConfigAnalysis              `json:"config_analysis,omitempty"`
+	ConfigChanges                []models.ConfigChange                `json:"config_changes,omitempty"`
+	ConfigItems                  []models.ConfigItem                  `json:"config_items,omitempty"`
+	CheckStatuses                []models.CheckStatus                 `json:"check_statuses,omitempty"`
+	ConfigRelationships          []models.ConfigRelationship          `json:"config_relationships,omitempty"`
+	ComponentRelationships       []models.ComponentRelationship       `json:"component_relationships,omitempty"`
+	ConfigComponentRelationships []models.ConfigComponentRelationship `json:"config_component_relationships,omitempty"`
+	Topologies                   []models.Topology                    `json:"topologies,omitempty"`
+}
+
+func (p *PushData) String() string {
+	result := ""
+	result += fmt.Sprintf("AgentName: %s\n", p.AgentName)
+	result += fmt.Sprintf("Topologies: %d\n", len(p.Topologies))
+	result += fmt.Sprintf("Canaries: %d\n", len(p.Canaries))
+	result += fmt.Sprintf("Checks: %d\n", len(p.Checks))
+	result += fmt.Sprintf("Components: %d\n", len(p.Components))
+	result += fmt.Sprintf("ConfigAnalysis: %d\n", len(p.ConfigAnalysis))
+	result += fmt.Sprintf("ConfigScrapers: %d\n", len(p.ConfigScrapers))
+	result += fmt.Sprintf("ConfigChanges: %d\n", len(p.ConfigChanges))
+	result += fmt.Sprintf("ConfigItems: %d\n", len(p.ConfigItems))
+	result += fmt.Sprintf("CheckStatuses: %d\n", len(p.CheckStatuses))
+	result += fmt.Sprintf("ConfigRelationships: %d\n", len(p.ConfigRelationships))
+	result += fmt.Sprintf("ComponentRelationships: %d\n", len(p.ComponentRelationships))
+	result += fmt.Sprintf("ConfigComponentRelationships: %d\n", len(p.ConfigComponentRelationships))
+	return result
+}
+
+// ReplaceTopologyID replaces the topology_id for all the components
+// with the provided id.
+func (t *PushData) ReplaceTopologyID(id *uuid.UUID) {
+	for i := range t.Components {
+		t.Components[i].TopologyID = id
+	}
+}
+
+// PopulateAgentID sets agent_id on all the data
+func (t *PushData) PopulateAgentID(id uuid.UUID) {
+	for i := range t.Canaries {
+		t.Canaries[i].AgentID = id
+	}
+	for i := range t.Checks {
+		t.Checks[i].AgentID = id
+	}
+	for i := range t.Components {
+		t.Components[i].AgentID = id
+	}
+	for i := range t.ConfigItems {
+		t.ConfigItems[i].AgentID = id
+	}
+	for i := range t.ConfigScrapers {
+		t.ConfigScrapers[i].AgentID = id
+	}
+	for i := range t.Topologies {
+		t.Topologies[i].AgentID = id
+	}
+}
+
+// ApplyLabels injects additional labels to the suitable fields
+func (t *PushData) ApplyLabels(labels map[string]string) {
+	for i := range t.Components {
+		t.Components[i].Labels = collections.MergeMap(t.Components[i].Labels, labels)
+	}
+
+	for i := range t.Checks {
+		t.Checks[i].Labels = collections.MergeMap(t.Checks[i].Labels, labels)
+	}
+
+	for i := range t.Canaries {
+		t.Canaries[i].Labels = collections.MergeMap(t.Canaries[i].Labels, labels)
+	}
+
+	for i := range t.Topologies {
+		t.Topologies[i].Labels = collections.MergeMap(t.Topologies[i].Labels, labels)
+	}
+}
+
+func GetIDsHash(ctx dbContext, table string, from uuid.UUID, size int) (*PaginateResponse, error) {
+	query := fmt.Sprintf(`
+		WITH id_list AS (
+			SELECT
+				id::TEXT
+			FROM %s
+			WHERE id > ?
+			ORDER BY id
+			LIMIT ?
+		)
+		SELECT
+			encode(digest(string_agg(id::TEXT, ''), 'sha256'), 'hex') as sha256sum,
+			MAX(id) as last_id,
+			COUNT(*) as total
+		FROM
+			id_list`, table)
+
+	var resp PaginateResponse
+	err := ctx.DB().Raw(query, from, size).Scan(&resp).Error
+	return &resp, err
+}
+
+func GetMissingResourceIDs(ctx dbContext, ids []string, paginateReq PaginateRequest) (*PushData, error) {
+	var pushData PushData
+
+	switch paginateReq.Table {
+	case "topologies":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.Topologies).Error; err != nil {
+			return nil, fmt.Errorf("error fetching topologies: %w", err)
+		}
+
+	case "canaries":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.Canaries).Error; err != nil {
+			return nil, fmt.Errorf("error fetching canaries: %w", err)
+		}
+
+	case "checks":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.Checks).Error; err != nil {
+			return nil, fmt.Errorf("error fetching checks: %w", err)
+		}
+
+	case "components":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.Components).Error; err != nil {
+			return nil, fmt.Errorf("error fetching components: %w", err)
+		}
+
+	case "config_scrapers":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.ConfigScrapers).Error; err != nil {
+			return nil, fmt.Errorf("error fetching config scrapers: %w", err)
+		}
+
+	case "config_items":
+		if err := ctx.DB().Not(ids).Where("id > ?", paginateReq.From).Limit(paginateReq.Size).Order("id").Find(&pushData.ConfigItems).Error; err != nil {
+			return nil, fmt.Errorf("error fetching config items: %w", err)
+		}
+	}
+
+	return &pushData, nil
+}
+
+// Push uploads the given push message to the upstream server.
+func Push(ctx context.Context, config UpstreamConfig, msg *PushData) error {
+	payloadBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(payloadBuf).Encode(msg); err != nil {
+		return fmt.Errorf("error encoding msg: %w", err)
+	}
+
+	endpoint, err := url.JoinPath(config.Host, "upstream", "push")
+	if err != nil {
+		return fmt.Errorf("error creating url endpoint for host %s: %w", config.Host, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, payloadBuf)
+	if err != nil {
+		return fmt.Errorf("http.NewRequest: %w", err)
+	}
+
+	req.SetBasicAuth(config.Username, config.Password)
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if !collections.Contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upstream server returned error status[%d]: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Migrated upstream logic from incident commander.
Also, added support for reconciling check statuses.

It'll be used by both canary check and by incident commander.