### PR TITLE
chore: change config_scrapers.{spec,source} to not null

### DIFF
--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -344,11 +344,11 @@ table "config_scrapers" {
     type = text
   }
   column "spec" {
-    null = true
+    null = false
     type = jsonb
   }
   column "source" {
-    null = true
+    null = false
     type = enum.source
   }
   column "created_by" {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/incident-commander/issues/488

Regarding upstream push,
So we had a bad spec for config scraper which caused all config_scrapers to fail which caused all config_items to fail. Since we don't use pointers for `source` and `spec` fields, these should be not null in the database as well