### PR TITLE
feat: playbook runs for checks

### DIFF
--- a/models/playbooks.go
+++ b/models/playbooks.go
@@ -39,6 +39,7 @@ type PlaybookRun struct {
 	EndTime     *time.Time          `json:"end_time,omitempty" time_format:"postgres_timestamp"`
 	CreatedBy   *uuid.UUID          `json:"created_by,omitempty"`
 	ComponentID *uuid.UUID          `json:"component_id,omitempty"`
+	CheckID     *uuid.UUID          `json:"check_id,omitempty"`
 	ConfigID    *uuid.UUID          `json:"config_id,omitempty"`
 	Parameters  types.JSONStringMap `json:"parameters,omitempty" gorm:"default:null"`
 	AgentID     *uuid.UUID          `json:"agent_id,omitempty"`

--- a/schema/playbooks.hcl
+++ b/schema/playbooks.hcl
@@ -134,6 +134,10 @@ table "playbook_runs" {
     null = true
     type = uuid
   }
+  column "check_id" {
+    null = true
+    type = uuid
+  }
   column "config_id" {
     null = true
     type = uuid
@@ -165,6 +169,12 @@ table "playbook_runs" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  foreign_key "playbook_run_check_id_fkey" {
+    columns     = [column.check_id]
+    ref_columns = [table.checks.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
   foreign_key "playbook_run_config_id_fkey" {
     columns     = [column.config_id]
     ref_columns = [table.config_items.column.id]
@@ -183,9 +193,13 @@ table "playbook_runs" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  check "check_component_or_config" {
-    expr    = "(((component_id IS NOT NULL) AND (config_id IS NULL)) OR ((config_id IS NOT NULL) AND (component_id IS NULL)))"
-    comment = "either a component id or a config id can be provided. and at least one of them is required."
+  check "check_component_or_config_or_check" {
+    expr    = <<EOF
+    (component_id IS NOT NULL AND config_id IS NULL AND check_id IS NULL) OR
+    (component_id IS NULL AND config_id IS NOT NULL AND check_id IS NULL) OR
+    (component_id IS NULL AND config_id IS NULL AND check_id IS NOT NULL)
+    EOF
+    comment = "Need exactly one of the following: check id, component id, or config id."
   }
 }
 

--- a/views/018_playbooks.sql
+++ b/views/018_playbooks.sql
@@ -18,39 +18,18 @@ AFTER INSERT OR UPDATE ON playbook_runs
 FOR EACH ROW
 EXECUTE PROCEDURE notify_playbook_run_update();
 
--- Notify playbook `spec.approval` updated
+-- Notify playbook updates
 CREATE OR REPLACE FUNCTION notify_playbook_update() 
 RETURNS TRIGGER AS $$
 DECLARE payload TEXT;
 BEGIN
   payload = NEW.id::TEXT;
   PERFORM pg_notify('playbook_updated', payload);
-
-  IF OLD.spec->'approval' != NEW.spec->'approval' THEN
-    PERFORM pg_notify('playbook_spec_approval_updated', payload);
-  END IF;
-    
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER playbook_update
+CREATE OR REPLACE TRIGGER playbook_updated_trigger
 AFTER UPDATE ON playbooks
 FOR EACH ROW
 EXECUTE PROCEDURE notify_playbook_update();
-
--- Notify playbook approvals insertion
-CREATE OR REPLACE FUNCTION notify_playbook_approvals_insert() 
-RETURNS TRIGGER AS $$
-DECLARE payload TEXT;
-BEGIN
-  payload = NEW.run_id::TEXT;
-  PERFORM pg_notify('playbook_approval_inserted', payload);
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE TRIGGER playbook_approvals_insert
-AFTER INSERT ON playbook_approvals
-FOR EACH ROW
-EXECUTE PROCEDURE notify_playbook_approvals_insert();


### PR DESCRIPTION
- Support playbook runs for checks
- put approval spec changes and new approvals to event queue instead of just publishing a notification.