### PR TITLE
chore: increase pool max conn size

### DIFF
--- a/db.go
+++ b/db.go
@@ -81,8 +81,8 @@ func NewPgxPool(connection string) (*pgxpool.Pool, error) {
 	}
 
 	// prevent deadlocks from concurrent queries
-	if config.MaxConns < 10 {
-		config.MaxConns = 10
+	if config.MaxConns < 20 {
+		config.MaxConns = 20
 	}
 
 	if logger.IsTraceEnabled() {


### PR DESCRIPTION
I'm now fairly certain the incident-commander new deployment is failing due to issues with connection pooling. We have about 12 event consumers now.

When some of those event consumers are not running, the health check runs fine.