### PR TITLE
fix: missing canaries in the UI (Settings -> Health Check)

### DIFF
--- a/views/015_job_history.sql
+++ b/views/015_job_history.sql
@@ -75,7 +75,6 @@ FROM
   canaries
   LEFT JOIN job_history_latest_status ON canaries.id::TEXT = job_history_latest_status.resource_id
   INNER JOIN canaries_last_runtime ON canaries_last_runtime.canary_id = canaries.id
-  AND job_history_latest_status.resource_type = 'canary'
 WHERE
   canaries.deleted_at IS NULL;
 


### PR DESCRIPTION
Now that we only have job history when it fails, this condition was preventing from canaries being returned.