### PR TITLE
fix: event_queue fixes

### DIFF
--- a/views/007_events.sql
+++ b/views/007_events.sql
@@ -4,7 +4,6 @@ RETURNS TRIGGER AS $$
 BEGIN
   IF OLD.spec->'approval' != NEW.spec->'approval' THEN
     INSERT INTO event_queue(name, properties) VALUES ('playbook.spec.approval.updated', jsonb_build_object('id', NEW.id));
-    NOTIFY event_queue_updates, 'playbook.spec.approval.updated';
   END IF;
     
   RETURN NULL;
@@ -21,7 +20,6 @@ CREATE OR REPLACE FUNCTION insert_new_playbook_approvals_to_event_queue()
 RETURNS TRIGGER AS $$
 BEGIN
   INSERT INTO event_queue(name, properties) VALUES ('playbook.approval.inserted', jsonb_build_object('id', NEW.id, 'run_id', NEW.run_id));
-  NOTIFY event_queue_updates, 'playbook.approval.inserted';
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -35,7 +33,6 @@ EXECUTE PROCEDURE insert_new_playbook_approvals_to_event_queue();
 CREATE OR REPLACE FUNCTION insert_incident_creation_in_event_queue() RETURNS TRIGGER AS $$
 BEGIN
     INSERT INTO event_queue(name, properties) VALUES ('incident.created', jsonb_build_object('id', NEW.id));
-    NOTIFY event_queue_updates, 'incident.created';
     RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
@@ -55,7 +52,6 @@ BEGIN
 
     event_name := 'incident.status.' || NEW.status;
     INSERT INTO event_queue(name, properties) VALUES (event_name, jsonb_build_object('id', NEW.id));
-    PERFORM pg_notify('event_queue_updates', event_name);
     RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
@@ -70,11 +66,9 @@ CREATE OR REPLACE FUNCTION insert_responder_in_event_queue() RETURNS TRIGGER AS 
 BEGIN
     IF TG_OP = 'INSERT' THEN
         INSERT INTO event_queue(name, properties) VALUES ('incident.responder.added', jsonb_build_object('id', NEW.id));
-        NOTIFY event_queue_updates, 'incident.responder.added';
     ELSIF TG_OP = 'UPDATE' THEN
         IF OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL THEN
             INSERT INTO event_queue(name, properties) VALUES ('incident.responder.removed', jsonb_build_object('id', NEW.id));
-            NOTIFY event_queue_updates, 'incident.responder.removed';
         END IF;
     END IF;
 
@@ -91,7 +85,6 @@ EXECUTE PROCEDURE insert_responder_in_event_queue();
 CREATE OR REPLACE FUNCTION insert_comment_in_event_queue () RETURNS TRIGGER AS $$
 BEGIN
     INSERT INTO event_queue(name, properties) VALUES ('incident.comment.added', jsonb_build_object('id', NEW.id));
-    NOTIFY event_queue_updates, 'incident.comment.added';
     RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
@@ -111,20 +104,16 @@ BEGIN
     IF OLD.definition_of_done != NEW.definition_of_done THEN
         IF NEW.definition_of_done THEN
             INSERT INTO event_queue(name, properties) VALUES ('incident.dod.added', jsonb_build_object('id', NEW.id));
-            NOTIFY event_queue_updates, 'incident.dod.added';
         ELSE
             INSERT INTO event_queue(name, properties) VALUES ('incident.dod.removed', jsonb_build_object('id', NEW.id));
-            NOTIFY event_queue_updates, 'incident.dod.removed';
         END IF;
     END IF;
 
     IF OLD.done != NEW.done THEN
         IF NEW.done THEN
             INSERT INTO event_queue(name, properties) VALUES ('incident.dod.passed', jsonb_build_object('id', NEW.id));
-            NOTIFY event_queue_updates, 'incident.dod.passed';
         ELSE
             INSERT INTO event_queue(name, properties) VALUES ('incident.dod.regressed', jsonb_build_object('id', NEW.id));
-            NOTIFY event_queue_updates, 'incident.dod.regressed';
         END IF;
     END IF;
     
@@ -146,10 +135,8 @@ BEGIN
 
     IF NEW.status = 'healthy' THEN
         INSERT INTO event_queue(name, properties) VALUES ('check.passed', jsonb_build_object('id', NEW.id)) ON CONFLICT (name, properties) DO NOTHING;
-        NOTIFY event_queue_updates, 'check.passed';
     ELSEIF NEW.status = 'unhealthy' THEN
         INSERT INTO event_queue(name, properties) VALUES ('check.failed', jsonb_build_object('id', NEW.id)) ON CONFLICT (name, properties) DO NOTHING;
-        NOTIFY event_queue_updates, 'check.failed';
     END IF;
 
     RETURN NULL;
@@ -172,7 +159,6 @@ BEGIN
     event_name := 'component.status.' || NEW.status;
     INSERT INTO event_queue(name, properties) VALUES (event_name, jsonb_build_object('id', NEW.id));
 
-    PERFORM pg_notify('event_queue_updates', event_name);
     RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
@@ -219,11 +205,9 @@ OR REPLACE FUNCTION insert_team_in_event_queue () RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'DELETE' THEN
     INSERT INTO event_queue(name, properties) VALUES ('team.delete', jsonb_build_object('team_id', OLD.id));
-    NOTIFY event_queue_updates, 'team.delete';
     RETURN OLD;
   ELSE
     INSERT INTO event_queue(name, properties) VALUES ('team.update', jsonb_build_object('team_id', NEW.id));
-    NOTIFY event_queue_updates, 'team.update';
     RETURN NEW;
   END IF;
 END
@@ -240,11 +224,9 @@ RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP = 'DELETE' THEN
         INSERT INTO event_queue(name, properties) VALUES ('notification.delete', jsonb_build_object('id', OLD.id));
-        NOTIFY event_queue_updates, 'notification.delete';
         RETURN OLD;
     ELSE
         INSERT INTO event_queue(name, properties) VALUES ('notification.update', jsonb_build_object('id', NEW.id));
-        NOTIFY event_queue_updates, 'notification.update';
         RETURN NEW;
     END IF;
 END
@@ -254,3 +236,19 @@ CREATE OR REPLACE TRIGGER notification_update_enqueue
 AFTER INSERT OR UPDATE OR DELETE ON notifications
 FOR EACH ROW
 EXECUTE PROCEDURE notifications_trigger_function ();
+
+-- Publish Notify on new events
+CREATE OR REPLACE FUNCTION notify_new_events_function()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM pg_notify('event_queue_updates', NEW.name);
+        RETURN NULL;
+    END IF;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER notify_new_events
+AFTER INSERT ON event_queue
+FOR EACH ROW
+EXECUTE PROCEDURE notify_new_events_function();


### PR DESCRIPTION
Async events, like `notification.send`, are created from the application; unlike sync events which are created with DB triggers. Due to this reason, we do not have PG notify triggers when async events are inserted. As a result, async event consumers never run in real-time and rely on the 1 minute timeout. (This was fine so far, because no matter which event was inserted, the pgnotify was picked up by all consumers. But now we have specific pg notify channels)

Instead of publishing pgnotify during insertion from multiple trigger functions, this PR adds a trigger on the event_queue table itself.

---

Also 
* added ON CONFLICT clauses on insertion to event queue
* Ignore adding to event queue if component.status = unknown

---
Resolves: https://github.com/flanksource/canary-checker/issues/1259