### PR TITLE
fix: pgx pool init

### DIFF
--- a/db.go
+++ b/db.go
@@ -64,10 +64,6 @@ func NewDB(connection string) (*sql.DB, error) {
 }
 
 func NewPgxPool(connection string) (*pgxpool.Pool, error) {
-	if pool != nil {
-		return pool, nil
-	}
-
 	pgUrl, err := url.Parse(connection)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	ariga.io/atlas v0.10.0
 	github.com/fergusstrange/embedded-postgres v1.21.0
 	github.com/flanksource/commons v1.11.0
-	github.com/flanksource/postq v0.1.0
+	github.com/flanksource/postq v0.1.1
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/hcl/v2 v2.16.2
 	github.com/itchyny/gojq v0.12.13

--- a/go.sum
+++ b/go.sum
@@ -711,8 +711,8 @@ github.com/flanksource/is-healthy v0.0.0-20230713150444-ad2a5ef4bb37 h1:MHXg2Vo/
 github.com/flanksource/is-healthy v0.0.0-20230713150444-ad2a5ef4bb37/go.mod h1:BH5gh9JyEAuuWVP6Q5y9h43VozS0RfKyjNpM9L4v4hw=
 github.com/flanksource/mapstructure v1.6.0 h1:+1kJ+QsO1SxjAgktfLlpZXetsVSJ0uCLhGKrA4BtwTE=
 github.com/flanksource/mapstructure v1.6.0/go.mod h1:dttg5+FFE2sp4D/CrcPCVqufNDrBggDaM+08nk5S8Ps=
-github.com/flanksource/postq v0.1.0 h1:z67bskZFaiKs6Nlzaw2U7FL4S1mu8BoCfonedt/fW70=
-github.com/flanksource/postq v0.1.0/go.mod h1:nE3mLh0vpF43TT+0HszC0QmORB37xSWPVHmhOY6PqBk=
+github.com/flanksource/postq v0.1.1 h1:QUIoCTj4M7YKN1+wxE7fwRrAQOgUEdk9s8I1hpa7fOM=
+github.com/flanksource/postq v0.1.1/go.mod h1:nE3mLh0vpF43TT+0HszC0QmORB37xSWPVHmhOY6PqBk=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
We use `NewPgxPool` for multiple databases now (in mission control tests)