### PR TITLE
fix: use distinct for children and parents in topology query

### DIFF
--- a/views/010_topology.sql
+++ b/views/010_topology.sql
@@ -17,7 +17,7 @@ WITH
   children AS (
     SELECT
       relationship_id AS id,
-      ARRAY_AGG(component_id) AS children
+      ARRAY_AGG(DISTINCT component_id) AS children
     FROM
       component_relationships
     WHERE
@@ -28,7 +28,7 @@ WITH
   parents AS (
     SELECT
       component_id AS id,
-      ARRAY_AGG(relationship_id) AS parents
+      ARRAY_AGG(DISTINCT relationship_id) AS parents
     FROM
       component_relationships
     WHERE


### PR DESCRIPTION
Parents were being duplicated in the result which led to duplication in the card view