### PR TITLE
fix: double quote in null string type

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -307,7 +307,7 @@ func (s NullString) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 	if s.String == "\"\"" {
-		s.String = ""
+		return []byte(""), nil
 	}
 	return json.Marshal(s.String)
 }
@@ -320,8 +320,13 @@ func (s *NullString) UnmarshalJSON(b []byte) error {
 		}
 		return nil
 	}
+
+	var val string
+	if err := json.Unmarshal(b, &val); err != nil {
+		return err
+	}
 	*s = NullString{
-		String: string(b),
+		String: val,
 		Valid:  true,
 	}
 	return nil


### PR DESCRIPTION
@moshloop Self-merging this

Fix for double-quotes in status reason:
![image](https://github.com/flanksource/duty/assets/5863972/5e83a518-89e6-4ee6-9e81-541f724e0600)
