### PR TITLE
feat: divide changelog migration script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/onsi/gomega v1.27.6
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/samber/lo v1.39.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
@@ -122,7 +123,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/robertkrimen/otto v0.2.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	github.com/samber/lo v1.39.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -657,8 +657,6 @@ github.com/antonmedv/expr v1.15.3/go.mod h1:0E/6TxnOlRNp81GMzX9QfDPAmHo2Phg00y4J
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -836,7 +834,6 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
@@ -1358,7 +1355,6 @@ github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE
 github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/hack/migrate/go.sum
+++ b/hack/migrate/go.sum
@@ -1251,6 +1251,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/views/012_changelog_trigger_func.sql
+++ b/views/012_changelog_trigger_func.sql
@@ -73,36 +73,3 @@ BEGIN
   RETURN NULL;
 END;
 $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
-
--- Apply trigger
-DO $$ 
-DECLARE 
-  table_name TEXT;
-BEGIN 
-  FOR table_name IN 
-    SELECT t.table_name 
-    FROM information_schema.tables  t
-    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
-      AND t.table_name IN (
-        'canaries',
-        'checks',
-        'components',
-        'config_scrapers',
-        'config_analysis',
-        'config_changes',
-        'config_items',
-        'config_component_relationships',
-        'component_relationships',
-        'config_relationships',
-        'topologies'
-      )
-  LOOP 
-    EXECUTE format('
-      CREATE OR REPLACE TRIGGER %1$I_change_to_event_queue
-      AFTER INSERT OR UPDATE ON %1$I
-      FOR EACH ROW
-      EXECUTE PROCEDURE push_changes_to_event_queue()',
-      table_name
-    );
-  END LOOP; 
-END $$;

--- a/views/012_changelog_triggers_checks.sql
+++ b/views/012_changelog_triggers_checks.sql
@@ -1,0 +1,22 @@
+-- Apply trigger
+DO $$ 
+DECLARE 
+  table_name TEXT;
+BEGIN 
+  FOR table_name IN 
+    SELECT t.table_name 
+    FROM information_schema.tables  t
+    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
+      AND t.table_name IN (
+        'checks'
+      )
+  LOOP 
+    EXECUTE format('
+      CREATE OR REPLACE TRIGGER %1$I_change_to_event_queue
+      AFTER INSERT OR UPDATE ON %1$I
+      FOR EACH ROW
+      EXECUTE PROCEDURE push_changes_to_event_queue()',
+      table_name
+    );
+  END LOOP; 
+END $$;

--- a/views/012_changelog_triggers_others.sql
+++ b/views/012_changelog_triggers_others.sql
@@ -1,0 +1,28 @@
+-- Apply trigger
+DO $$ 
+DECLARE 
+  table_name TEXT;
+BEGIN 
+  FOR table_name IN 
+    SELECT t.table_name 
+    FROM information_schema.tables  t
+    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
+      AND t.table_name IN (
+        'canaries',
+        'components',
+        'config_scrapers',
+        'config_component_relationships',
+        'component_relationships',
+        'config_relationships',
+        'topologies'
+      )
+  LOOP 
+    EXECUTE format('
+      CREATE OR REPLACE TRIGGER %1$I_change_to_event_queue
+      AFTER INSERT OR UPDATE ON %1$I
+      FOR EACH ROW
+      EXECUTE PROCEDURE push_changes_to_event_queue()',
+      table_name
+    );
+  END LOOP; 
+END $$;

--- a/views/012_changelog_triggers_scrapers.sql
+++ b/views/012_changelog_triggers_scrapers.sql
@@ -1,0 +1,24 @@
+-- Apply trigger
+DO $$ 
+DECLARE 
+  table_name TEXT;
+BEGIN 
+  FOR table_name IN 
+    SELECT t.table_name 
+    FROM information_schema.tables  t
+    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
+      AND t.table_name IN (
+        'config_analysis',
+        'config_changes',
+        'config_items'
+      )
+  LOOP 
+    EXECUTE format('
+      CREATE OR REPLACE TRIGGER %1$I_change_to_event_queue
+      AFTER INSERT OR UPDATE ON %1$I
+      FOR EACH ROW
+      EXECUTE PROCEDURE push_changes_to_event_queue()',
+      table_name
+    );
+  END LOOP; 
+END $$;


### PR DESCRIPTION
This way config-db, canary-checker can only apply changelog triggers that they need.