### PR TITLE
fix: only set job meta if unset

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -242,7 +242,7 @@ func (k Context) StartSpan(name string) (Context, trace.Span) {
 func getObjectMeta(ctx commons.Context) metav1.ObjectMeta {
 	o := ctx.Value("object")
 	if o == nil {
-		return metav1.ObjectMeta{Annotations: map[string]string{}, Labels: map[string]string{}}
+		return metav1.ObjectMeta{Annotations: make(map[string]string), Labels: make(map[string]string)}
 	}
 	return o.(metav1.ObjectMeta)
 }


### PR DESCRIPTION
Incorrect namespace (due to overriding of object meta) was being used in topologies, causing connections to break (they depend on ctx.GetNamespace())