### PR TITLE
feat: agent auth middleware

### DIFF
--- a/tests/upstream_test.go
+++ b/tests/upstream_test.go
@@ -48,7 +48,9 @@ var _ = ginkgo.Describe("Config Changes & Analyses sync test", ginkgo.Ordered, f
 			}
 		})
 
-		e.POST("/upstream/push", upstream.PushHandler(cache.New(time.Hour, time.Hour)))
+		e.Use(upstream.AgentAuthMiddleware(cache.New(time.Hour, time.Hour)))
+
+		e.POST("/upstream/push", upstream.PushHandler())
 		e.GET("/upstream/pull/:agent_name", upstream.PullHandler([]string{"config_scrapers", "config_items"}))
 		e.GET("/upstream/status/:agent_name", upstream.StatusHandler([]string{"config_scrapers", "config_items"}))
 

--- a/tests/upstream_test.go
+++ b/tests/upstream_test.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("Config Changes & Analyses sync test", ginkgo.Ordered, f
 
 		e.Use(upstream.AgentAuthMiddleware(cache.New(time.Hour, time.Hour)))
 
-		e.POST("/upstream/push", upstream.PushHandler())
+		e.POST("/upstream/push", upstream.PushHandler)
 		e.GET("/upstream/pull/:agent_name", upstream.PullHandler([]string{"config_scrapers", "config_items"}))
 		e.GET("/upstream/status/:agent_name", upstream.StatusHandler([]string{"config_scrapers", "config_items"}))
 

--- a/tests/upstream_test.go
+++ b/tests/upstream_test.go
@@ -51,8 +51,8 @@ var _ = ginkgo.Describe("Config Changes & Analyses sync test", ginkgo.Ordered, f
 		e.Use(upstream.AgentAuthMiddleware(cache.New(time.Hour, time.Hour)))
 
 		e.POST("/upstream/push", upstream.PushHandler)
-		e.GET("/upstream/pull/:agent_name", upstream.PullHandler([]string{"config_scrapers", "config_items"}))
-		e.GET("/upstream/status/:agent_name", upstream.StatusHandler([]string{"config_scrapers", "config_items"}))
+		e.GET("/upstream/pull", upstream.PullHandler([]string{"config_scrapers", "config_items"}))
+		e.GET("/upstream/status", upstream.StatusHandler([]string{"config_scrapers", "config_items"}))
 
 		port, echoCloser = setup.RunEcho(e)
 
@@ -61,6 +61,7 @@ var _ = ginkgo.Describe("Config Changes & Analyses sync test", ginkgo.Ordered, f
 			AgentName: agentName,
 		}
 	})
+
 	ginkgo.It("should push config items first to satisfy foregin keys for changes & analyses", func() {
 		reconciler := upstream.NewUpstreamReconciler(upstreamConf, 100)
 

--- a/upstream/client.go
+++ b/upstream/client.go
@@ -80,9 +80,9 @@ func (t *UpstreamClient) push(ctx context.Context, method string, msg *PushData)
 	}
 
 	start := time.Now()
-	msg.AddMetrics(ctx.Counter("push_queue_records", "method", method, "agent", msg.AgentName))
-	histogram := ctx.Histogram("push_queue_batch", "method", method, "agent", msg.AgentName)
-	req := t.R(ctx).QueryParam(AgentNameQueryParam, msg.AgentName)
+	msg.AddMetrics(ctx.Counter("push_queue_records", "method", method, "agent", t.AgentName))
+	histogram := ctx.Histogram("push_queue_batch", "method", method, "agent", t.AgentName)
+	req := t.R(ctx).QueryParam(AgentNameQueryParam, t.AgentName)
 	if err := req.Body(msg); err != nil {
 		return fmt.Errorf("error setting body: %w", err)
 	}

--- a/upstream/client.go
+++ b/upstream/client.go
@@ -11,6 +11,10 @@ import (
 	"github.com/google/uuid"
 )
 
+// AgentNameQueryParam is the name of the query param that's used to authenticate an
+// agent when using basic auth instead of access tokens.
+const AgentNameQueryParam = "agent_name"
+
 type UpstreamClient struct {
 	AgentName string
 	*http.Client
@@ -52,7 +56,7 @@ func (t *UpstreamClient) PushArtifacts(ctx context.Context, artifactID uuid.UUID
 
 // Ping sends a ping message to the upstream
 func (t *UpstreamClient) Ping(ctx context.Context) error {
-	resp, err := t.Client.R(ctx).QueryParam("agent_name", t.AgentName).Get("/ping")
+	resp, err := t.Client.R(ctx).QueryParam(AgentNameQueryParam, t.AgentName).Get("/ping")
 	if !resp.IsOK() {
 		return fmt.Errorf("upstream sent an unexpected response: %v", resp.StatusCode)
 	}
@@ -78,7 +82,7 @@ func (t *UpstreamClient) push(ctx context.Context, method string, msg *PushData)
 	start := time.Now()
 	msg.AddMetrics(ctx.Counter("push_queue_records", "method", method, "agent", msg.AgentName))
 	histogram := ctx.Histogram("push_queue_batch", "method", method, "agent", msg.AgentName)
-	req := t.R(ctx).QueryParam("agent_name", msg.AgentName)
+	req := t.R(ctx).QueryParam(AgentNameQueryParam, msg.AgentName)
 	if err := req.Body(msg); err != nil {
 		return fmt.Errorf("error setting body: %w", err)
 	}

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -52,8 +52,7 @@ func AgentAuthMiddleware(agentCache *cache.Cache) func(echo.HandlerFunc) echo.Ha
 				if err != nil {
 					histogram.Label(StatusLabel, StatusAgentError)
 					return c.JSON(http.StatusBadRequest, api.HTTPError{
-						Error:   err.Error(),
-						Message: "Error while creating/fetching agent",
+						Error: fmt.Errorf("failed to create/fetch agent: %w", err).Error(),
 					})
 				}
 

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -37,7 +37,7 @@ func AgentAuthMiddleware(agentCache *cache.Cache) func(echo.HandlerFunc) echo.Ha
 
 			histogram := ctx.Histogram("agent_auth_middleware")
 
-			agentName := c.QueryParam("agent_name")
+			agentName := c.QueryParam(AgentNameQueryParam)
 			if agentName == "" {
 				histogram.Label(StatusLabel, StatusAgentError)
 				return c.JSON(http.StatusBadRequest, api.HTTPError{Error: "agent name is required"})

--- a/upstream/event_consumer.go
+++ b/upstream/event_consumer.go
@@ -26,9 +26,7 @@ func NewDeleteFromUpstreamConsumer(config UpstreamConfig) func(ctx context.Conte
 
 // DeleteFromUpstream sends a delete request to the upstream server for the given events.
 func DeleteFromUpstream(ctx context.Context, config UpstreamConfig, events []postq.Event) []postq.Event {
-	upstreamMsg := &PushData{
-		AgentName: config.AgentName,
-	}
+	upstreamMsg := &PushData{}
 
 	var failedEvents []postq.Event
 	for _, cl := range GroupChangelogsByTables(events) {
@@ -121,9 +119,7 @@ func NewPushUpstreamConsumer(config UpstreamConfig) func(ctx context.Context, ev
 func PushToUpstream(ctx context.Context, config UpstreamConfig, events []postq.Event) []postq.Event {
 	ctx, span := ctx.StartSpan("PushToUpstream")
 	defer span.End()
-	upstreamMsg := &PushData{
-		AgentName: config.AgentName,
-	}
+	upstreamMsg := &PushData{}
 
 	var failedEvents []postq.Event
 	for _, cl := range GroupChangelogsByTables(events) {

--- a/upstream/jobs.go
+++ b/upstream/jobs.go
@@ -29,7 +29,7 @@ func SyncCheckStatuses(ctx context.Context, config UpstreamConfig, batchSize int
 		}
 
 		ctx.Tracef("pushing %d check_statuses to upstream", len(checkStatuses))
-		if err := client.Push(ctx, &PushData{AgentName: config.AgentName, CheckStatuses: checkStatuses}); err != nil {
+		if err := client.Push(ctx, &PushData{CheckStatuses: checkStatuses}); err != nil {
 			return 0, fmt.Errorf("failed to push check_statuses to upstream: %w", err)
 		}
 
@@ -64,7 +64,7 @@ func SyncConfigChanges(ctx context.Context, config UpstreamConfig, batchSize int
 		}
 
 		ctx.Tracef("pushing %d config_changes to upstream", len(configChanges))
-		if err := client.Push(ctx, &PushData{AgentName: config.AgentName, ConfigChanges: configChanges}); err != nil {
+		if err := client.Push(ctx, &PushData{ConfigChanges: configChanges}); err != nil {
 			return 0, fmt.Errorf("failed to push config_changes to upstream: %w", err)
 		}
 
@@ -97,7 +97,7 @@ func SyncConfigAnalyses(ctx context.Context, config UpstreamConfig, batchSize in
 		}
 
 		ctx.Tracef("pushing %d config_analyses to upstream", len(analyses))
-		if err := client.Push(ctx, &PushData{AgentName: config.AgentName, ConfigAnalysis: analyses}); err != nil {
+		if err := client.Push(ctx, &PushData{ConfigAnalysis: analyses}); err != nil {
 			return 0, fmt.Errorf("failed to push config_analysis to upstream: %w", err)
 		}
 
@@ -128,7 +128,7 @@ func SyncArtifacts(ctx context.Context, config UpstreamConfig, batchSize int) (i
 		}
 
 		ctx.Tracef("pushing %d artifacts to upstream", len(artifacts))
-		if err := client.Push(ctx, &PushData{AgentName: config.AgentName, Artifacts: artifacts}); err != nil {
+		if err := client.Push(ctx, &PushData{Artifacts: artifacts}); err != nil {
 			return 0, fmt.Errorf("failed to push artifacts to upstream: %w", err)
 		}
 

--- a/upstream/reconcile.go
+++ b/upstream/reconcile.go
@@ -185,6 +185,7 @@ func (t *UpstreamReconciler) createPaginateRequest(ctx gocontext.Context, reques
 	return t.upstreamClient.R(ctx).
 		QueryParam("table", request.Table).
 		QueryParam("from", request.From).
+		QueryParam("agent_name", t.upstreamConf.AgentName).
 		QueryParam("size", fmt.Sprintf("%d", request.Size))
 }
 

--- a/upstream/reconcile.go
+++ b/upstream/reconcile.go
@@ -118,7 +118,6 @@ func (t *UpstreamReconciler) sync(ctx context.Context, table, next string) (int,
 		if pushData != nil && pushData.Count() > 0 {
 			logger.WithValues("table", table).Debugf("Pushing %d items to upstream. Next: %q", pushData.Count(), next)
 
-			pushData.AgentName = t.upstreamConf.AgentName
 			if err := t.upstreamClient.Push(ctx, pushData); err != nil {
 				errorList = append(errorList, fmt.Errorf("failed to push missing resource ids: %w", err))
 			}

--- a/upstream/reconcile.go
+++ b/upstream/reconcile.go
@@ -135,8 +135,8 @@ func (t *UpstreamReconciler) sync(ctx context.Context, table, next string) (int,
 // fetchUpstreamResourceIDs requests all the existing resource ids from the upstream
 // that were sent by this agent.
 func (t *UpstreamReconciler) fetchUpstreamResourceIDs(ctx context.Context, request PaginateRequest) ([]string, error) {
-	httpReq := t.createPaginateRequest(ctx, request)
-	httpResponse, err := httpReq.Get(fmt.Sprintf("pull/%s", t.upstreamConf.AgentName))
+	httpReq := t.createPaginateRequest(ctx, request).QueryParam(AgentNameQueryParam, t.upstreamConf.AgentName)
+	httpResponse, err := httpReq.Get("pull")
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %w", err)
 	}
@@ -159,11 +159,12 @@ func (t *UpstreamReconciler) fetchUpstreamResourceIDs(ctx context.Context, reque
 }
 
 func (t *UpstreamReconciler) fetchUpstreamStatus(ctx gocontext.Context, request PaginateRequest) (*PaginateResponse, error) {
-	httpReq := t.createPaginateRequest(ctx, request)
-	httpResponse, err := httpReq.Get(fmt.Sprintf("status/%s", t.upstreamConf.AgentName))
+	httpReq := t.createPaginateRequest(ctx, request).QueryParam(AgentNameQueryParam, t.upstreamConf.AgentName)
+	httpResponse, err := httpReq.Get("status")
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %w", err)
 	}
+
 	body, err := httpResponse.AsString()
 	if err != nil {
 		return nil, fmt.Errorf("error reading body: %w", err)
@@ -185,7 +186,6 @@ func (t *UpstreamReconciler) createPaginateRequest(ctx gocontext.Context, reques
 	return t.upstreamClient.R(ctx).
 		QueryParam("table", request.Table).
 		QueryParam("from", request.From).
-		QueryParam("agent_name", t.upstreamConf.AgentName).
 		QueryParam("size", fmt.Sprintf("%d", request.Size))
 }
 

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -60,7 +60,6 @@ func (t *UpstreamConfig) LabelsMap() map[string]string {
 // PushData consists of data about changes to
 // components, configs, analysis.
 type PushData struct {
-	AgentName                    string                               `json:"agent_name,omitempty"`
 	Canaries                     []models.Canary                      `json:"canaries,omitempty"`
 	Checks                       []models.Check                       `json:"checks,omitempty"`
 	Components                   []models.Component                   `json:"components,omitempty"`
@@ -93,6 +92,7 @@ func (p *PushData) AddMetrics(counter context.Counter) {
 	counter.Label("table", "playbook_actions").Add(len(p.PlaybookActions))
 	counter.Label("table", "topologies").Add(len(p.Topologies))
 }
+
 func (p *PushData) String() string {
 	result := ""
 	for k, v := range p.Attributes() {
@@ -102,9 +102,7 @@ func (p *PushData) String() string {
 }
 
 func (p *PushData) Attributes() map[string]any {
-	attrs := map[string]any{
-		"name": p.AgentName,
-	}
+	attrs := map[string]any{}
 
 	if len(p.Topologies) > 0 {
 		attrs["Topologies"] = len(p.Topologies)


### PR DESCRIPTION
This PR 
- creates a middleware for all agent authentication. (works for both access token based & query param based authentication)
- supplying the agent name via query param is more streamlined and doesn't need to be set manually in all places.