### PR TITLE
fix: fix broken schemas reference to definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ download-openapi-schemas:
 	git clone --depth=1 git@github.com:flanksource/canary-checker.git tmp/canary-checker && cp tmp/canary-checker/config/schemas/* schema/openapi/
 
 	# create schemas for specs only
-	cat tmp/canary-checker/config/schemas/canary.schema.json | jq '.["$$ref"] = "#/definitions/CanarySpec"' > schema/openapi/canary.spec.schema.json
-	cat tmp/canary-checker/config/schemas/component.schema.json | jq '.["$$ref"] = "#/definitions/ComponentSpec"' > schema/openapi/component.spec.schema.json
-	cat tmp/canary-checker/config/schemas/topology.schema.json | jq '.["$$ref"] = "#/definitions/TopologySpec"' > schema/openapi/topology.spec.schema.json
+	cat tmp/canary-checker/config/schemas/canary.schema.json | jq '.["$$ref"] = "#/$defs/CanarySpec"' > schema/openapi/canary.spec.schema.json
+	cat tmp/canary-checker/config/schemas/component.schema.json | jq '.["$$ref"] = "#/$defs/ComponentSpec"' > schema/openapi/component.spec.schema.json
+	cat tmp/canary-checker/config/schemas/topology.schema.json | jq '.["$$ref"] = "#/$defs/TopologySpec"' > schema/openapi/topology.spec.schema.json
 
 	# Config DB
 	git clone --depth=1 git@github.com:flanksource/config-db.git tmp/config-db && cp tmp/config-db/config/schemas/* schema/openapi/

--- a/schema/openapi/canary.spec.schema.json
+++ b/schema/openapi/canary.spec.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/flanksource/canary-checker/api/v1/canary",
-  "$ref": "#/definitions/CanarySpec",
+  "$ref": "#/$defs/CanarySpec",
   "$defs": {
     "AWSConnection": {
       "properties": {

--- a/schema/openapi/component.spec.schema.json
+++ b/schema/openapi/component.spec.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/flanksource/canary-checker/api/v1/component",
-  "$ref": "#/definitions/ComponentSpec",
+  "$ref": "#/$defs/ComponentSpec",
   "$defs": {
     "AWSConnection": {
       "properties": {

--- a/schema/openapi/topology.spec.schema.json
+++ b/schema/openapi/topology.spec.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/flanksource/canary-checker/api/v1/topology",
-  "$ref": "#/definitions/TopologySpec",
+  "$ref": "#/$defs/TopologySpec",
   "$defs": {
     "AWSConnection": {
       "properties": {


### PR DESCRIPTION
This fixes a few issues that are due to inconsistencies, some schema definitions are under definitions properties and others are under $def property and this breaking the canary, topology and component schemas, but not config specs