### PR TITLE
feat: add error column to playbooks

### DIFF
--- a/models/playbooks.go
+++ b/models/playbooks.go
@@ -76,6 +76,7 @@ type PlaybookRun struct {
 	ComponentID   *uuid.UUID          `json:"component_id,omitempty"`
 	CheckID       *uuid.UUID          `json:"check_id,omitempty"`
 	ConfigID      *uuid.UUID          `json:"config_id,omitempty"`
+	Error         *string             `json:"error,omitempty"`
 	Parameters    types.JSONStringMap `json:"parameters,omitempty" gorm:"default:null"`
 	AgentID       *uuid.UUID          `json:"agent_id,omitempty"`
 }

--- a/schema/playbooks.hcl
+++ b/schema/playbooks.hcl
@@ -173,6 +173,10 @@ table "playbook_runs" {
     default = var.uuid_nil
     type = uuid
   }
+  column "error" {
+    null = true
+    type = text
+  }
   primary_key {
     columns = [column.id]
   }


### PR DESCRIPTION
This is for errors that are not related to actions. Example:
- db errors when fetching the playbook
- when a non existent playbook id is supplied
- when a playbook delay expression is invalid (the delay is in action but its parsed by the run consumer.)