### PR TITLE
chore: change delimiter to allow func parsing

### DIFF
--- a/context/template.go
+++ b/context/template.go
@@ -29,7 +29,7 @@ func (k Context) NewStructTemplater(vals map[string]any, requiredTag string, fun
 		RequiredTag:    requiredTag,
 		DelimSets: []gomplate.Delims{
 			{Left: "{{", Right: "}}"},
-			{Left: "$(", Right: ")"},
+			{Left: "$((", Right: "))"},
 		},
 	}
 }


### PR DESCRIPTION
```
$((catalog_traverse .config.id  "Kubernetes::Kustomization/Kubernetes::GitRepository").Config | json | jq `.spec.url` | quote)
```

Gets parsed incorrectly as it takes the first `)` as closing paren