### PR TITLE
feat: add pagination and more filtering in catalog changes

### DIFF
--- a/query/commons.go
+++ b/query/commons.go
@@ -33,13 +33,13 @@ func parseAndBuildFilteringQuery(query string, field string) ([]string, map[stri
 
 	in, notIN, prefixes, suffixes := ParseFilteringQuery(query)
 	if len(in) > 0 {
-		clauses = append(clauses, fmt.Sprintf("%s IN @field_in", field))
-		args["field_in"] = in
+		clauses = append(clauses, fmt.Sprintf("%s IN @%s_field_in", field, field))
+		args[fmt.Sprintf("%s_field_in", field)] = in
 	}
 
 	if len(notIN) > 0 {
-		clauses = append(clauses, fmt.Sprintf("%s NOT IN @field_not_in", field))
-		args["field_not_in"] = notIN
+		clauses = append(clauses, fmt.Sprintf("%s NOT IN @%s_field_not_in", field, field))
+		args[fmt.Sprintf("%s_field_not_in", field)] = notIN
 	}
 
 	for i, p := range prefixes {

--- a/query/config_changes.go
+++ b/query/config_changes.go
@@ -21,15 +21,40 @@ const (
 )
 
 type CatalogChangesSearchRequest struct {
-	CatalogID  uuid.UUID `query:"id"`
-	ConfigType string    `query:"config_type"`
-	ChangeType string    `query:"type"`
-	From       string    `query:"from"`
+	CatalogID             uuid.UUID `query:"id"`
+	ConfigType            string    `query:"config_type"`
+	ChangeType            string    `query:"type"`
+	Severity              string    `query:"severity"`
+	IncludeDeletedConfigs bool      `query:"include_deleted_configs"`
+
+	// From date in datemath format
+	From string `query:"from"`
+	// To date in datemath format
+	To string `query:"to"`
+
+	PageSize int    `query:"page_size"`
+	Page     int    `query:"page"`
+	SortBy   string `query:"sort_by"`
 
 	// upstream | downstream | both
 	Recursive string `query:"recursive"`
 
 	fromParsed time.Time
+	toParsed   time.Time
+}
+
+func (t *CatalogChangesSearchRequest) SetDefaults() {
+	if t.PageSize <= 0 {
+		t.PageSize = 50
+	}
+
+	if t.Page <= 0 {
+		t.Page = 1
+	}
+
+	if t.From == "" && t.To == "" {
+		t.From = "now-2d"
+	}
 }
 
 func (t *CatalogChangesSearchRequest) Validate() error {
@@ -49,6 +74,18 @@ func (t *CatalogChangesSearchRequest) Validate() error {
 		}
 	}
 
+	if t.To != "" {
+		if expr, err := datemath.Parse(t.To); err != nil {
+			return fmt.Errorf("invalid 'to' param: %w", err)
+		} else {
+			t.toParsed = expr.Time()
+		}
+	}
+
+	if !t.fromParsed.IsZero() && !t.toParsed.IsZero() && !t.fromParsed.Before(t.toParsed) {
+		return fmt.Errorf("'from' must be before 'to'")
+	}
+
 	return nil
 }
 
@@ -65,17 +102,19 @@ func (t *CatalogChangesSearchResponse) Summarize() {
 }
 
 func FindCatalogChanges(ctx context.Context, req CatalogChangesSearchRequest) (*CatalogChangesSearchResponse, error) {
+	req.SetDefaults()
 	if err := req.Validate(); err != nil {
 		return nil, api.Errorf(api.EINVALID, "bad request: %v", err)
 	}
 
 	args := map[string]any{
-		"catalog_id": req.CatalogID,
-		"recursive":  req.Recursive,
+		"catalog_id":              req.CatalogID,
+		"recursive":               req.Recursive,
+		"include_deleted_configs": req.IncludeDeletedConfigs,
 	}
 
 	var clauses []string
-	query := "SELECT cc.* FROM related_changes_recursive(@catalog_id, @recursive) cc"
+	query := "SELECT cc.* FROM related_changes_recursive(@catalog_id, @recursive, @include_deleted_configs) cc"
 	if req.Recursive == "" {
 		query = "SELECT cc.* FROM config_changes cc"
 		clauses = append(clauses, "cc.config_id = @catalog_id")
@@ -95,14 +134,40 @@ func FindCatalogChanges(ctx context.Context, req CatalogChangesSearchRequest) (*
 		args = collections.MergeMap(args, _args)
 	}
 
+	if req.Severity != "" {
+		_clauses, _args := parseAndBuildFilteringQuery(req.Severity, "cc.severity")
+		clauses = append(clauses, _clauses...)
+		args = collections.MergeMap(args, _args)
+	}
+
 	if !req.fromParsed.IsZero() {
-		clauses = append(clauses, "cc.created_at >= @from")
+		clauses = append(clauses, "cc.created_at > @from")
 		args["from"] = req.fromParsed
+	}
+
+	if !req.toParsed.IsZero() {
+		clauses = append(clauses, "cc.created_at < @to")
+		args["to"] = req.toParsed
 	}
 
 	if len(clauses) > 0 {
 		query += fmt.Sprintf(" WHERE %s", strings.Join(clauses, " AND "))
 	}
+
+	if req.SortBy != "" {
+		var sortOrder = "ASC"
+		if strings.HasPrefix(string(req.SortBy), "-") {
+			sortOrder = "DESC"
+			req.SortBy = strings.TrimPrefix(string(req.SortBy), "-")
+		}
+
+		query += fmt.Sprintf(" ORDER BY @sortby %s", sortOrder)
+		args["sortby"] = req.SortBy
+	}
+
+	query += " LIMIT @page_size OFFSET @page_number"
+	args["page_size"] = req.PageSize
+	args["page_number"] = (req.Page - 1) * req.PageSize
 
 	var output CatalogChangesSearchResponse
 	if err := ctx.DB().Raw(query, args).Find(&output.Changes).Error; err != nil {

--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -162,6 +162,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 			})
 			Expect(err).To(BeNil())
 			Expect(len(response.Changes)).To(Equal(1))
+			Expect(response.Total).To(Equal(1))
 			Expect(response.Summary[UChange.ChangeType]).To(Equal(1))
 		})
 
@@ -173,6 +174,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					ConfigType: "Kubernetes::Pod,Kubernetes::ReplicaSet",
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(3))
 				Expect(len(response.Changes)).To(Equal(3))
 				Expect(response.Summary["Pulled"]).To(Equal(2))
 				Expect(response.Summary["diff"]).To(Equal(1))
@@ -185,6 +187,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					ConfigType: "!Kubernetes::ReplicaSet",
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(5))
 				Expect(len(response.Changes)).To(Equal(5))
 				Expect(response.Summary["diff"]).To(Equal(2))
 				Expect(response.Summary["Pulled"]).To(Equal(2))
@@ -200,6 +203,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					ChangeType: "diff",
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(2))
 				Expect(len(response.Changes)).To(Equal(2))
 				Expect(response.Summary["diff"]).To(Equal(2))
 			})
@@ -211,6 +215,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					ChangeType: "!diff,!Pulled",
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(1))
 				Expect(len(response.Changes)).To(Equal(1))
 				Expect(response.Summary["RegisterNode"]).To(Equal(1))
 			})
@@ -223,6 +228,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				Severity:  "!info",
 			})
 			Expect(err).To(BeNil())
+			Expect(response.Total).To(Equal(3))
 			Expect(len(response.Changes)).To(Equal(3))
 			Expect(response.Summary["Pulled"]).To(Equal(1))
 			Expect(response.Summary["diff"]).To(Equal(2))
@@ -237,6 +243,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					PageSize:  2,
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(6))
 				Expect(len(response.Changes)).To(Equal(2))
 				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.Summary })
 				Expect(changes).To(Equal([]string{".name.U", ".name.V"}))
@@ -251,35 +258,10 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					Page:      2,
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(6))
 				Expect(len(response.Changes)).To(Equal(2))
 				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.Summary })
 				Expect(changes).To(Equal([]string{".name.W", ".name.X"}))
-			})
-		})
-
-		ginkgo.Context("Sorting", func() {
-			ginkgo.It("Ascending", func() {
-				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
-					CatalogID: U.ID,
-					Recursive: query.CatalogChangeRecursiveDownstream,
-					SortBy:    "change_type",
-				})
-				Expect(err).To(BeNil())
-				Expect(len(response.Changes)).To(Equal(6))
-				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.ChangeType })
-				Expect(changes).To(Equal([]string{"diff", "diff", "diff", "Pulled", "Pulled", "RegisterNode"}))
-			})
-
-			ginkgo.It("Descending", func() {
-				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
-					CatalogID: U.ID,
-					Recursive: query.CatalogChangeRecursiveDownstream,
-					SortBy:    "-catalog_name",
-				})
-				Expect(err).To(BeNil())
-				Expect(len(response.Changes)).To(Equal(6))
-				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.CatalogName })
-				Expect(changes).To(Equal([]string{"Z", "Y", "X", "W", "V", "U"}))
 			})
 		})
 
@@ -291,6 +273,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(2))
+				Expect(response.Total).To(Equal(2))
 				Expect(response.Summary[UChange.ChangeType]).To(Equal(1))
 				Expect(response.Summary[WChange.ChangeType]).To(Equal(1))
 			})
@@ -302,6 +285,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(4))
+				Expect(response.Total).To(Equal(4))
 				Expect(response.Summary["diff"]).To(Equal(3))
 				Expect(response.Summary["Pulled"]).To(Equal(1))
 			})
@@ -313,6 +297,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(5))
+				Expect(response.Total).To(Equal(5))
 				Expect(response.Summary["diff"]).To(Equal(3))
 				Expect(response.Summary["Pulled"]).To(Equal(1))
 				Expect(response.Summary["RegisterNode"]).To(Equal(1))
@@ -328,9 +313,38 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					To:        "now-1s",
 				})
 				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(2))
 				Expect(len(response.Changes)).To(Equal(2))
 				Expect(response.Summary["diff"]).To(Equal(1))
 				Expect(response.Summary["RegisterNode"]).To(Equal(1))
+			})
+		})
+
+		ginkgo.Context("Sorting", func() {
+			ginkgo.It("Descending", func() {
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					CatalogID: U.ID,
+					Recursive: query.CatalogChangeRecursiveDownstream,
+					SortBy:    "-catalog_name",
+				})
+				Expect(err).To(BeNil())
+				Expect(len(response.Changes)).To(Equal(6))
+				Expect(response.Total).To(Equal(6))
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.CatalogName })
+				Expect(changes).To(Equal([]string{"Z", "Y", "X", "W", "V", "U"}))
+			})
+
+			ginkgo.It("Ascending", func() {
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					CatalogID: U.ID,
+					Recursive: query.CatalogChangeRecursiveDownstream,
+					SortBy:    "catalog_name",
+				})
+				Expect(err).To(BeNil())
+				Expect(response.Total).To(Equal(6))
+				Expect(len(response.Changes)).To(Equal(6))
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.CatalogName })
+				Expect(changes).To(Equal([]string{"U", "V", "W", "X", "Y", "Z"}))
 			})
 		})
 	})

--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -238,7 +238,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(2))
-				changes := lo.Map(response.Changes, func(c models.ConfigChange, _ int) string { return c.Summary })
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.Summary })
 				Expect(changes).To(Equal([]string{".name.U", ".name.V"}))
 			})
 
@@ -252,7 +252,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(2))
-				changes := lo.Map(response.Changes, func(c models.ConfigChange, _ int) string { return c.Summary })
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.Summary })
 				Expect(changes).To(Equal([]string{".name.W", ".name.X"}))
 			})
 		})
@@ -266,7 +266,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(6))
-				changes := lo.Map(response.Changes, func(c models.ConfigChange, _ int) string { return c.ChangeType })
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.ChangeType })
 				Expect(changes).To(Equal([]string{"diff", "diff", "diff", "Pulled", "Pulled", "RegisterNode"}))
 			})
 
@@ -274,12 +274,12 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
 					CatalogID: U.ID,
 					Recursive: query.CatalogChangeRecursiveDownstream,
-					SortBy:    "-change_type",
+					SortBy:    "-catalog_name",
 				})
 				Expect(err).To(BeNil())
 				Expect(len(response.Changes)).To(Equal(6))
-				changes := lo.Map(response.Changes, func(c models.ConfigChange, _ int) string { return c.ChangeType })
-				Expect(changes).To(Equal([]string{"RegisterNode", "Pulled", "Pulled", "diff", "diff", "diff"}))
+				changes := lo.Map(response.Changes, func(c query.ConfigChangeRow, _ int) string { return c.CatalogName })
+				Expect(changes).To(Equal([]string{"Z", "Y", "X", "W", "V", "U"}))
 			})
 		})
 


### PR DESCRIPTION
- add pagination (sortby, pagesize, page)
- return the catalog name as well
- filter by
  - severity
  - `to` date
  - inclusion of deleted configs