### PR TITLE
feat: pass in the properties while templating connection

### DIFF
--- a/context/connection.go
+++ b/context/connection.go
@@ -184,6 +184,14 @@ func HydrateConnection(ctx Context, connection *models.Connection) (*models.Conn
 		return nil, err
 	}
 
+	for k, v := range connection.Properties {
+		if v, err = GetEnvStringFromCache(ctx, v, connection.Namespace); err != nil {
+			return nil, err
+		} else {
+			connection.Properties[k] = v
+		}
+	}
+
 	domain := ""
 	parts := strings.Split(connection.Username, "@")
 	if len(parts) == 2 {
@@ -191,12 +199,13 @@ func HydrateConnection(ctx Context, connection *models.Connection) (*models.Conn
 	}
 
 	data := map[string]interface{}{
-		"name":      connection.Name,
-		"type":      connection.Type,
-		"namespace": connection.Namespace,
-		"username":  connection.Username,
-		"password":  connection.Password,
-		"domain":    domain,
+		"name":       connection.Name,
+		"type":       connection.Type,
+		"namespace":  connection.Namespace,
+		"username":   connection.Username,
+		"password":   connection.Password,
+		"domain":     domain,
+		"properties": connection.Properties,
 	}
 	templater := gomplate.StructTemplater{
 		Values: data,

--- a/context/connection_test.go
+++ b/context/connection_test.go
@@ -1,6 +1,13 @@
 package context
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	commons "github.com/flanksource/commons/context"
+	"github.com/flanksource/duty/models"
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestGetConnectionNameType(t *testing.T) {
 	testCases := []struct {
@@ -119,6 +126,47 @@ func TestGetConnectionNameType(t *testing.T) {
 			}
 			if found != tc.Expect.found {
 				t.Errorf("g.Expected found %t, but got %t", tc.Expect.found, found)
+			}
+		})
+	}
+}
+
+func TestHydrateConnection(t *testing.T) {
+	dummyContext := Context{
+		Context: commons.NewContext(context.Background()),
+	}
+
+	testCases := []struct {
+		name       string
+		connection models.Connection
+		expect     string
+	}{
+		{
+			name: "properties templating",
+			connection: models.Connection{
+				URL:      "postgres://$(username):$(password)@$(properties.host):$(properties.port)/$(properties.database)",
+				Username: "the-username",
+				Password: "the-password",
+				Properties: map[string]string{
+					"host":     "localhost",
+					"database": "mission_control",
+					"port":     "5443",
+				},
+			},
+			expect: "postgres://the-username:the-password@localhost:5443/mission_control",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := HydrateConnection(dummyContext, &tc.connection)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+
+			if diff := cmp.Diff(tc.expect, resp.URL); diff != "" {
+				t.Logf("mismatch: wanted=%s got=%s", tc.expect, resp.URL)
+				t.Fatalf("diff: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
pass in the connection's properties during hydration. It also supports env var strings.

---
it was need because right now we only have three fields that can store env vars (username, password & certificate). If I needed to save a postgres connection host and database, for example, it wasn't possible.

Now it's possible to store the connection as `postgres://$(username):$(password)@$(properties.host):$(properties.port)/$(properties.database)` and the connection properties can be

```json
{
  "properties": {
    "database": "secret://postgres/database",
   "host": "secret://postgres/host"
  }
}
```