### PR TITLE
fix: remove duplicate index

### DIFF
--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -325,9 +325,6 @@ table "config_items" {
     columns = [column.tags]
     type    = GIN
   }
-  index "idx_config_items_agent" {
-    columns = [column.agent_id]
-  }
   index "idx_config_items_name" {
     columns = [column.agent_id, column.name, column.type, column.config_class]
   }


### PR DESCRIPTION
`idx_config_items_agent` is covered by `idx_config_items_name`