### PR TITLE
feat: handle foreign key error during reconciliation

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -10,6 +10,10 @@ import (
 type HTTPError struct {
 	Error   string `json:"error"`
 	Message string `json:"message,omitempty"`
+
+	// Data for machine-machine communication.
+	// usually contains a JSON data.
+	Data string `json:"data,omitempty"`
 }
 
 type HTTPSuccess struct {
@@ -18,13 +22,13 @@ type HTTPSuccess struct {
 }
 
 func WriteError(c echo.Context, err error) error {
-	code, message := ErrorCode(err), ErrorMessage(err)
+	code, message, data := ErrorCode(err), ErrorMessage(err), ErrorData(err)
 
 	if debugInfo := ErrorDebugInfo(err); debugInfo != "" {
 		logger.WithValues("code", code, "error", message).Errorf(debugInfo)
 	}
 
-	return c.JSON(ErrorStatusCode(code), &HTTPError{Error: message})
+	return c.JSON(ErrorStatusCode(code), &HTTPError{Error: message, Data: data})
 }
 
 // ErrorStatusCode returns the associated HTTP status code for an application error code.

--- a/db.go
+++ b/db.go
@@ -3,6 +3,7 @@ package duty
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -15,6 +16,8 @@ import (
 	dutyGorm "github.com/flanksource/duty/gorm"
 	"github.com/flanksource/duty/migrate"
 	"github.com/flanksource/duty/tracing"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/spf13/pflag"
@@ -205,4 +208,13 @@ func SetupDB(connection string, migrateOpts *migrate.MigrateOptions) (gormDB *go
 	}
 
 	return
+}
+
+func IsForeignKeyError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgerrcode.ForeignKeyViolation
+	}
+
+	return false
 }

--- a/hack/migrate/go.mod
+++ b/hack/migrate/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.14 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/pgx/v5 v5.5.1 // indirect

--- a/hack/migrate/go.sum
+++ b/hack/migrate/go.sum
@@ -1075,6 +1075,8 @@ github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/pgconn v1.14.0 h1:vrbA9Ud87g6JdFWkHTJXppVce58qPIdP7N8y0Ml/A7Q=
 github.com/jackc/pgconn v1.14.0/go.mod h1:9mBNlny0UvkgJdCDvdVHYSjI+8tD2rnKK69Wz8ti++E=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/job/check_status.go
+++ b/job/check_status.go
@@ -42,7 +42,7 @@ func AggregateCheckStatus1d(ctx context.Context) (int, error) {
 		SUM(duration) AS duration
 	FROM check_statuses
 	LEFT JOIN checks ON check_statuses.check_id = checks.id
-	WHERE checks.created_at > NOW() - INTERVAL '1 hour' * ?
+	WHERE check_statuses.time > NOW() - INTERVAL '1 hour' * ?
 	GROUP BY 1, 2
 	ORDER BY 1,	2 DESC`
 
@@ -84,7 +84,7 @@ func AggregateCheckStatus1h(ctx context.Context) (int, error) {
 		SUM(duration) AS duration
 	FROM check_statuses
 	LEFT JOIN checks ON check_statuses.check_id = checks.id
-	WHERE checks.created_at > NOW() - INTERVAL '1 hour' * ?
+	WHERE check_statuses.time  > NOW() - INTERVAL '1 hour' * ?
 	GROUP BY 1, 2
 	ORDER BY 1,	2 DESC`
 

--- a/models/common.go
+++ b/models/common.go
@@ -1,6 +1,10 @@
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"gorm.io/gorm/clause"
+)
 
 type Severity string
 
@@ -39,4 +43,11 @@ func asMap(t any, removeFields ...string) map[string]any {
 type DBTable interface {
 	PK() string
 	TableName() string
+}
+
+// TODO: Find a better way to handle this
+type ExtendedDBTable interface {
+	DBTable
+	Value() any
+	PKCols() []clause.Column
 }

--- a/models/config.go
+++ b/models/config.go
@@ -100,6 +100,14 @@ type ConfigItem struct {
 	DeleteReason    string               `json:"delete_reason,omitempty"`
 }
 
+func (t ConfigItem) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) error {
+	parentIDs := lo.Map(items, func(item DBTable, _ int) string {
+		return lo.FromPtr(item.(ConfigItem).ScraperID)
+	})
+
+	return db.Model(&ConfigScraper{}).Where("id IN ?", parentIDs).Update("is_pushed", false).Error
+}
+
 func (t ConfigItem) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 	var items []ConfigItem
 	err := db.Where("is_pushed IS FALSE").Find(&items).Error

--- a/models/config.go
+++ b/models/config.go
@@ -311,6 +311,26 @@ type ConfigRelationship struct {
 	DeletedAt  *time.Time `json:"deleted_at,omitempty"`
 }
 
+func (c ConfigRelationship) Value() any {
+	return &c
+}
+
+func (c ConfigRelationship) PKCols() []clause.Column {
+	return []clause.Column{{Name: "related_id"}, {Name: "config_id"}, {Name: "selector_id"}}
+}
+
+func (t ConfigRelationship) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) error {
+	parentIDs := lo.Map(items, func(item DBTable, _ int) string {
+		return item.(ConfigRelationship).ConfigID
+	})
+
+	relatedIDs := lo.Map(items, func(item DBTable, _ int) string {
+		return item.(ConfigRelationship).RelatedID
+	})
+
+	return db.Model(&ConfigItem{}).Where("id IN ?", append(parentIDs, relatedIDs...)).Update("is_pushed", false).Error
+}
+
 func (s ConfigRelationship) UpdateIsPushed(db *gorm.DB, items []DBTable) error {
 	ids := lo.Map(items, func(a DBTable, _ int) []string {
 		c := any(a).(ConfigRelationship)
@@ -357,6 +377,14 @@ type ConfigChange struct {
 	IsPushed bool `json:"is_pushed,omitempty"`
 }
 
+func (t ConfigChange) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) error {
+	parentIDs := lo.Map(items, func(item DBTable, _ int) string {
+		return item.(ConfigChange).ConfigID
+	})
+
+	return db.Model(&ConfigItem{}).Where("id IN ?", parentIDs).Update("is_pushed", false).Error
+}
+
 func (t ConfigChange) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 	var items []ConfigChange
 	err := db.Select("config_changes.*").
@@ -364,6 +392,14 @@ func (t ConfigChange) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 		Where("config_items.agent_id = ?", uuid.Nil).
 		Where("config_changes.is_pushed IS FALSE").Find(&items).Error
 	return lo.Map(items, func(i ConfigChange, _ int) DBTable { return i }), err
+}
+
+func (c ConfigChange) PKCols() []clause.Column {
+	return []clause.Column{{Name: "id"}}
+}
+
+func (c ConfigChange) Value() any {
+	return &c
 }
 
 func (c ConfigChange) PK() string {
@@ -397,7 +433,7 @@ func (c *ConfigChange) BeforeCreate(tx *gorm.DB) error {
 }
 
 type ConfigAnalysis struct {
-	ID            uuid.UUID     `gorm:"primaryKey;unique_index;not null;column:id" json:"id"`
+	ID            uuid.UUID     `gorm:"primaryKey;unique_index;not null;column:id;default:generate_ulid()" json:"id"`
 	ExternalID    string        `gorm:"-"`
 	ConfigType    string        `gorm:"-"`
 	ConfigID      uuid.UUID     `gorm:"column:config_id;default:''" json:"config_id"`
@@ -416,6 +452,14 @@ type ConfigAnalysis struct {
 	IsPushed bool `json:"is_pushed,omitempty"`
 }
 
+func (t ConfigAnalysis) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) error {
+	parentIDs := lo.Map(items, func(item DBTable, _ int) string {
+		return item.(ConfigAnalysis).ConfigID.String()
+	})
+
+	return db.Model(&ConfigItem{}).Where("id IN ?", parentIDs).Update("is_pushed", false).Error
+}
+
 func (ConfigAnalysis) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 	var items []ConfigAnalysis
 	err := db.Select("config_analysis.*").
@@ -424,6 +468,14 @@ func (ConfigAnalysis) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 		Where("config_analysis.is_pushed IS FALSE").
 		Find(&items).Error
 	return lo.Map(items, func(i ConfigAnalysis, _ int) DBTable { return i }), err
+}
+
+func (c ConfigAnalysis) PKCols() []clause.Column {
+	return []clause.Column{{Name: "id"}}
+}
+
+func (c ConfigAnalysis) Value() any {
+	return &c
 }
 
 func (a ConfigAnalysis) PK() string {

--- a/models/config.go
+++ b/models/config.go
@@ -71,7 +71,7 @@ var AllowedColumnFieldsInConfigs = []string{"config_class", "external_id"}
 
 // ConfigItem represents the config item database table
 type ConfigItem struct {
-	ID              uuid.UUID            `json:"id" faker:"uuid_hyphenated"`
+	ID              uuid.UUID            `json:"id" faker:"uuid_hyphenated" gorm:"default:generate_ulid()"`
 	ScraperID       *string              `json:"scraper_id,omitempty"`
 	AgentID         uuid.UUID            `json:"agent_id,omitempty"`
 	ConfigClass     string               `json:"config_class" faker:"oneof:File,EC2Instance,KubernetesPod" `
@@ -343,7 +343,7 @@ type ConfigChange struct {
 	ExternalID       string     `gorm:"-" json:"-"`
 	ConfigType       string     `gorm:"-" json:"-"`
 	ExternalChangeId string     `gorm:"column:external_change_id" json:"external_change_id"`
-	ID               string     `gorm:"primaryKey;unique_index;not null;column:id" json:"id"`
+	ID               string     `gorm:"primaryKey;unique_index;not null;column:id;default:generate_ulid()" json:"id"`
 	ConfigID         string     `gorm:"column:config_id;default:''" json:"config_id"`
 	ChangeType       string     `gorm:"column:change_type" json:"change_type" faker:"oneof:  RunInstances, diff" `
 	Severity         Severity   `gorm:"column:severity" json:"severity"  faker:"oneof: critical, high, medium, low, info"`

--- a/tests/upstream_test.go
+++ b/tests/upstream_test.go
@@ -203,30 +203,26 @@ var _ = ginkgo.Describe("Reconcile Test", ginkgo.Ordered, func() {
 				SelectorID: utils.RandomString(10),
 			}
 
+			all := []any{&deployment, &pod, &deploymentChange, &podChange, &deploymentAnalysis, &podAnalysis, &deploymentPodRelationship}
+
 			ginkgo.BeforeAll(func() {
-				err := DefaultContext.DB().Create(&deployment).Error
-				Expect(err).To(BeNil())
+				for _, a := range all {
+					err := DefaultContext.DB().Create(a).Error
+					Expect(err).To(BeNil())
+				}
+			})
 
-				err = DefaultContext.DB().Create(&pod).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&deploymentChange).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&podChange).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&podChange).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&deploymentAnalysis).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&podAnalysis).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&deploymentPodRelationship).Error
-				Expect(err).To(BeNil())
+			ginkgo.AfterAll(func() {
+				var err error
+				for _, a := range lo.Reverse(all) {
+					switch v := a.(type) {
+					case *models.ConfigRelationship:
+						err = DefaultContext.DB().Where("selector_id = ?", v.SelectorID).Delete(a).Error
+					default:
+						err = DefaultContext.DB().Delete(a).Error
+					}
+					Expect(err).To(BeNil())
+				}
 			})
 
 			for _, t := range []string{"config_changes", "config_analysis", "config_relationships"} {
@@ -281,18 +277,19 @@ var _ = ginkgo.Describe("Reconcile Test", ginkgo.Ordered, func() {
 				Name:     "tcp check",
 			}
 
+			all := []any{&httpCanary, &httpChecks, &tcpCanary, &tcpCheck}
 			ginkgo.BeforeAll(func() {
-				err := DefaultContext.DB().Create(&httpCanary).Error
-				Expect(err).To(BeNil())
+				for _, a := range all {
+					err := DefaultContext.DB().Create(a).Error
+					Expect(err).To(BeNil())
+				}
+			})
 
-				err = DefaultContext.DB().Create(&tcpCanary).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&httpChecks).Error
-				Expect(err).To(BeNil())
-
-				err = DefaultContext.DB().Create(&tcpCheck).Error
-				Expect(err).To(BeNil())
+			ginkgo.AfterAll(func() {
+				for _, a := range all {
+					err := DefaultContext.DB().Delete(a).Error
+					Expect(err).To(BeNil())
+				}
 			})
 
 			ginkgo.It("should reconcile the above canary & checks", func() {

--- a/tests/upstream_test.go
+++ b/tests/upstream_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
 
+	"github.com/flanksource/commons/utils"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/tests/setup"
@@ -62,7 +65,7 @@ var _ = ginkgo.Describe("Reconcile Test", ginkgo.Ordered, func() {
 		}
 	})
 
-	ginkgo.It("should push config items first to satisfy foregin keys for changes & analyses", func() {
+	ginkgo.It("should push config items first to satisfy foreign keys for changes & analyses", func() {
 		count, err := upstream.ReconcileSome(DefaultContext, upstreamConf, 100, "config_items")
 		Expect(err).To(BeNil())
 		Expect(count).To(Not(BeZero()))
@@ -146,7 +149,60 @@ var _ = ginkgo.Describe("Reconcile Test", ginkgo.Ordered, func() {
 		err = DefaultContext.DB().Select("COUNT(*)").Where("is_pushed = false").Model(&models.Artifact{}).Scan(&pending).Error
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pending).To(BeZero())
+	})
 
+	ginkgo.It("should deal with fk constraint errors", func() {
+		airsonic := models.ConfigItem{
+			Name:        lo.ToPtr("airsonic"),
+			Type:        lo.ToPtr("Kubernetes::Pod"),
+			Config:      lo.ToPtr("{}"),
+			ConfigClass: "Pod",
+		}
+		err := DefaultContext.DB().Create(&airsonic).Error
+		Expect(err).To(BeNil())
+
+		navidrome := models.ConfigItem{
+			Name:        lo.ToPtr("navidrome"),
+			Type:        lo.ToPtr("Kubernetes::Pod"),
+			Config:      lo.ToPtr("{}"),
+			ConfigClass: "Pod",
+		}
+		err = DefaultContext.DB().Create(&navidrome).Error
+		Expect(err).To(BeNil())
+
+		airsonicchange := models.ConfigChange{
+			ConfigID:         airsonic.ID.String(),
+			ExternalChangeId: utils.RandomString(10),
+			ChangeType:       "Pending",
+		}
+		err = DefaultContext.DB().Create(&airsonicchange).Error
+		Expect(err).To(BeNil())
+
+		navidromeChange := models.ConfigChange{
+			ConfigID:         navidrome.ID.String(),
+			ExternalChangeId: utils.RandomString(10),
+			ChangeType:       "Running",
+		}
+		err = DefaultContext.DB().Create(&navidromeChange).Error
+		Expect(err).To(BeNil())
+
+		// Pretend that these config items have been pushed already even though
+		// they haven't been
+		err = DefaultContext.DB().Model(&models.ConfigItem{}).
+			Where("id IN ?", []uuid.UUID{airsonic.ID, navidrome.ID}).UpdateColumn("is_pushed", true).Error
+		Expect(err).To(BeNil())
+
+		count, err := upstream.ReconcileSome(DefaultContext, upstreamConf, 10, "config_changes")
+		Expect(err).To(HaveOccurred())
+		Expect(count).To(Equal(0))
+
+		// After reconciliation, those config items should have been marked as unpushed.
+		var unpushed int
+		err = DefaultContext.DB().Model(&models.ConfigItem{}).Select("COUNT(*)").
+			Where("id IN ?", []uuid.UUID{airsonic.ID, navidrome.ID}).
+			Where("is_pushed", false).Scan(&unpushed).Error
+		Expect(err).To(BeNil())
+		Expect(unpushed).To(Equal(2))
 	})
 
 	ginkgo.AfterAll(func() {

--- a/upstream/commands.go
+++ b/upstream/commands.go
@@ -156,7 +156,7 @@ func InsertUpstreamMsg(ctx context.Context, req *PushData) error {
 	}
 
 	if len(req.ConfigRelationships) > 0 {
-		if err := db.Clauses(clause.OnConflict{UpdateAll: true, Columns: models.ConfigComponentRelationship{}.PKCols()}).CreateInBatches(req.ConfigRelationships, batchSize).Error; err != nil {
+		if err := db.Clauses(clause.OnConflict{UpdateAll: true, Columns: models.ConfigRelationship{}.PKCols()}).CreateInBatches(req.ConfigRelationships, batchSize).Error; err != nil {
 			return handleUpsertError(ctx, lo.Map(req.ConfigRelationships, func(i models.ConfigRelationship, _ int) models.ExtendedDBTable { return i }), err)
 		}
 	}

--- a/upstream/commands.go
+++ b/upstream/commands.go
@@ -61,12 +61,6 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 		}
 	}
 
-	if len(req.ConfigScrapers) > 0 {
-		if err := db.Delete(req.ConfigScrapers).Error; err != nil {
-			return fmt.Errorf("error deleting config scrapers: %w", err)
-		}
-	}
-
 	if len(req.ConfigRelationships) > 0 {
 		if err := db.Delete(req.ConfigRelationships).Error; err != nil {
 			return fmt.Errorf("error deleting config_relationships: %w", err)
@@ -76,6 +70,24 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 	if len(req.ConfigComponentRelationships) > 0 {
 		if err := db.Delete(req.ConfigComponentRelationships).Error; err != nil {
 			return fmt.Errorf("error deleting config_component_relationships: %w: %+v", err, req.ConfigComponentRelationships)
+		}
+	}
+
+	if len(req.ConfigChanges) > 0 {
+		if err := db.Delete(req.ConfigChanges).Error; err != nil {
+			return fmt.Errorf("error deleting config changes: %w", err)
+		}
+	}
+
+	if len(req.ConfigAnalysis) > 0 {
+		if err := db.Delete(req.ConfigAnalysis).Error; err != nil {
+			return fmt.Errorf("error deleting config analysis: %w", err)
+		}
+	}
+
+	if len(req.CheckStatuses) > 0 {
+		if err := db.Delete(req.CheckStatuses).Error; err != nil {
+			return fmt.Errorf("error deleting check_statuses: %w", err)
 		}
 	}
 
@@ -91,15 +103,15 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 		}
 	}
 
-	if len(req.CheckStatuses) > 0 {
-		if err := db.Delete(req.CheckStatuses).Error; err != nil {
-			return fmt.Errorf("error deleting check_statuses: %w", err)
-		}
-	}
-
 	if len(req.Checks) > 0 {
 		if err := db.Delete(req.Checks).Error; err != nil {
 			return fmt.Errorf("error deleting checks: %w", err)
+		}
+	}
+
+	if len(req.ConfigScrapers) > 0 {
+		if err := db.Delete(req.ConfigScrapers).Error; err != nil {
+			return fmt.Errorf("error deleting config scrapers: %w", err)
 		}
 	}
 

--- a/upstream/commands.go
+++ b/upstream/commands.go
@@ -55,24 +55,6 @@ func GetOrCreateAgent(ctx context.Context, name string) (*models.Agent, error) {
 func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 	db := ctx.DB()
 
-	if len(req.Topologies) > 0 {
-		if err := db.Delete(req.Topologies).Error; err != nil {
-			return fmt.Errorf("error deleting topologies: %w", err)
-		}
-	}
-
-	if len(req.Canaries) > 0 {
-		if err := db.Delete(req.Canaries).Error; err != nil {
-			return fmt.Errorf("error deleting canaries: %w", err)
-		}
-	}
-
-	if len(req.Components) > 0 {
-		if err := db.Delete(req.Components).Error; err != nil {
-			logger.Errorf("error deleting components: %w", err)
-		}
-	}
-
 	if len(req.ComponentRelationships) > 0 {
 		if err := db.Delete(req.ComponentRelationships).Error; err != nil {
 			return fmt.Errorf("error deleting component_relationships: %w", err)
@@ -85,12 +67,6 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 		}
 	}
 
-	if len(req.ConfigItems) > 0 {
-		if err := db.Delete(req.ConfigItems).Error; err != nil {
-			logger.Errorf("error deleting config items: %w", err)
-		}
-	}
-
 	if len(req.ConfigRelationships) > 0 {
 		if err := db.Delete(req.ConfigRelationships).Error; err != nil {
 			return fmt.Errorf("error deleting config_relationships: %w", err)
@@ -99,7 +75,25 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 
 	if len(req.ConfigComponentRelationships) > 0 {
 		if err := db.Delete(req.ConfigComponentRelationships).Error; err != nil {
-			return fmt.Errorf("error deleting config_component_relationships: %w", err)
+			return fmt.Errorf("error deleting config_component_relationships: %w: %+v", err, req.ConfigComponentRelationships)
+		}
+	}
+
+	if len(req.Components) > 0 {
+		if err := db.Delete(req.Components).Error; err != nil {
+			logger.Errorf("error deleting components: %w", err)
+		}
+	}
+
+	if len(req.ConfigItems) > 0 {
+		if err := db.Delete(req.ConfigItems).Error; err != nil {
+			logger.Errorf("error deleting config items: %w", err)
+		}
+	}
+
+	if len(req.CheckStatuses) > 0 {
+		if err := db.Delete(req.CheckStatuses).Error; err != nil {
+			return fmt.Errorf("error deleting check_statuses: %w", err)
 		}
 	}
 
@@ -109,9 +103,15 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 		}
 	}
 
-	if len(req.CheckStatuses) > 0 {
-		if err := db.Delete(req.CheckStatuses).Error; err != nil {
-			return fmt.Errorf("error deleting check_statuses: %w", err)
+	if len(req.Canaries) > 0 {
+		if err := db.Delete(req.Canaries).Error; err != nil {
+			return fmt.Errorf("error deleting canaries: %w", err)
+		}
+	}
+
+	if len(req.Topologies) > 0 {
+		if err := db.Delete(req.Topologies).Error; err != nil {
+			return fmt.Errorf("error deleting topologies: %w", err)
 		}
 	}
 

--- a/views/016_check_status.sql
+++ b/views/016_check_status.sql
@@ -17,7 +17,7 @@ FROM
   check_statuses
   LEFT JOIN checks ON check_statuses.check_id = checks.id
 WHERE
-  checks.created_at > now() - INTERVAL '1 day'
+  check_statuses.time > now() - INTERVAL '1 day'
 GROUP BY
   check_id,
   date_trunc('minute', "time") - (date_part('minute', "time")::INT % 5) * INTERVAL '1 minute'


### PR DESCRIPTION
The plan is that if the upstream gets any fk constraint error
- it does the insert/update one by one and keeps a list of all the items that failed due to fk constraint error
- the agent then marks the parent(s) of those failed items as `is_pushed=false`
- In the next round of reconciliation, the conflict will get resolved (or we could restart the round immediately after this round ends)

resolves: https://github.com/flanksource/duty/issues/689