### PR TITLE
feat: clear out stale running job histories for singleton jobs

### DIFF
--- a/job/cleanup.go
+++ b/job/cleanup.go
@@ -8,32 +8,15 @@ import (
 	"github.com/flanksource/duty/models"
 )
 
-func CleanupStaleHistoryJob(ctx context.Context, age time.Duration, name, resourceID string) *Job {
-	return &Job{
-		Context:    ctx,
-		Name:       "CleanupStaleJobHistory",
-		Schedule:   "@every 24h",
-		Singleton:  true,
-		JobHistory: true,
-		Retention:  RetentionFew,
-		RunNow:     true,
-		Fn: func(ctx JobRuntime) error {
-			count, err := cleanupStaleHistory(ctx.Context, age, name, resourceID)
-			if err != nil {
-				return err
-			}
-
-			ctx.History.SuccessCount = count
-			return nil
-		},
-	}
-}
-
-func cleanupStaleHistory(ctx context.Context, age time.Duration, name, resourceID string) (int, error) {
+func CleanupStaleHistory(ctx context.Context, age time.Duration, name, resourceID string, statuses ...string) (int, error) {
 	ctx = ctx.WithName(fmt.Sprintf("job=%s", name)).WithName(fmt.Sprintf("resourceID=%s", resourceID))
+
 	query := ctx.DB().Where("NOW() - time_start >= ?", age)
 	if name != "" {
 		query = query.Where("name = ?", name)
+	}
+	if len(statuses) != 0 {
+		query = query.Where("status IN ?", statuses)
 	}
 	if resourceID != "" {
 		query = query.Where("resource_id = ?", resourceID)

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -39,7 +39,7 @@ func TestStatusRing(t *testing.T) {
 	for i := range cases {
 		td := cases[i]
 		eg.Go(func() error {
-			sr := newStatusRing(td, ch)
+			sr := newStatusRing(td, false, ch)
 			for i := 0; i < 100; i++ {
 				sr.Add(&models.JobHistory{ID: uuid.New(), Status: string(models.StatusSuccess)})
 				sr.Add(&models.JobHistory{ID: uuid.New(), Status: string(models.StatusFinished)})


### PR DESCRIPTION
resolves: https://github.com/flanksource/duty/issues/727

1. The stale running job histories of singleton jobs will now be cleared by the status ring itself.
2. For stale running job histories of deleted resources _(i.e. the job doesn't run anymore)_, the cleanup job in mission control will call `CleanupStaleHistoryJob` with a smaller stale age _(probably 4 hours)_ just for running statuses.