### PR TITLE
fix: cleanup trigger that adds push_queue.create events

### DIFF
--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -707,3 +707,7 @@ EXECUTE PROCEDURE insert_parent_to_config_relationship();
 DROP VIEW IF EXISTS config_statuses;
 CREATE or REPLACE VIEW config_statuses AS
   SELECT DISTINCT status FROM config_items WHERE status IS NOT NULL ORDER BY status;
+
+-- Cleanup old trigger that used to add 'push_queue.create' events
+-- for any changes on a selected list of tables.
+DROP FUNCTION IF EXISTS push_changes_to_event_queue CASCADE;


### PR DESCRIPTION
These triggers were cleared up in the AWS cluster, but for some reason it remained on the Demo cluster but only for two tables: config_changes, config_analysis.



```
SELECT  properties->>'table', COUNT(*) FROM event_queue WHERE name = 'push_queue.create' GROUP BY properties->>'table'
+-----------------+-------+
| ?column?        | count |
|-----------------+-------|
| config_analysis | 1333  |
| config_changes  | 57254 |
+-----------------+-------+
```