### PR TITLE
fix: upstream error propagation

### DIFF
--- a/upstream/client.go
+++ b/upstream/client.go
@@ -109,9 +109,9 @@ func (t *UpstreamClient) push(ctx context.Context, method string, msg *PushData)
 		histogram.Label(StatusLabel, StatusError).Since(start)
 		respBody, _ := io.ReadAll(resp.Body)
 
-		var upstreamError api.Error
-		if json.Unmarshal(respBody, &upstreamError) == nil {
-			return &upstreamError
+		var httpErr api.HTTPError
+		if json.Unmarshal(respBody, &httpErr) == nil {
+			return &httpErr
 		}
 
 		return fmt.Errorf("upstream server returned error status[%d]: %s", resp.StatusCode, parseResponse(string(respBody)))

--- a/upstream/commands.go
+++ b/upstream/commands.go
@@ -258,7 +258,10 @@ func handleUpsertError(ctx context.Context, items []models.ExtendedDBTable, err 
 		}
 	}
 
-	return api.Errorf(api.ECONFLICT, "foreign key error").WithData(PushFKError{IDs: lo.Uniq(conflicted)})
+	conflicted = lo.Uniq(conflicted)
+	return api.Errorf(api.ECONFLICT, "foreign key error").
+		WithData(PushFKError{IDs: conflicted}).
+		WithDebugInfo("foreign key error for %d items", len(conflicted))
 }
 
 func UpdateAgentLastSeen(ctx context.Context, id uuid.UUID) error {

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -38,7 +38,7 @@ func AgentAuthMiddleware(agentCache *cache.Cache) func(echo.HandlerFunc) echo.Ha
 			agentName := c.QueryParam(AgentNameQueryParam)
 			if agentName == "" {
 				histogram.Label(StatusLabel, StatusAgentError)
-				return c.JSON(http.StatusBadRequest, api.HTTPError{Error: "agent name is required"})
+				return c.JSON(http.StatusBadRequest, api.HTTPError{Err: "agent name is required"})
 			}
 
 			var agent *models.Agent
@@ -50,7 +50,7 @@ func AgentAuthMiddleware(agentCache *cache.Cache) func(echo.HandlerFunc) echo.Ha
 				if err != nil {
 					histogram.Label(StatusLabel, StatusAgentError)
 					return c.JSON(http.StatusBadRequest, api.HTTPError{
-						Error: fmt.Errorf("failed to create/fetch agent: %w", err).Error(),
+						Err: fmt.Errorf("failed to create/fetch agent: %w", err).Error(),
 					})
 				}
 
@@ -78,7 +78,7 @@ func PushHandler(c echo.Context) error {
 	err := json.NewDecoder(c.Request().Body).Decode(&req)
 	if err != nil {
 		histogram.Label(StatusLabel, StatusAgentError)
-		return c.JSON(http.StatusBadRequest, api.HTTPError{Error: err.Error(), Message: "invalid json request"})
+		return c.JSON(http.StatusBadRequest, api.HTTPError{Err: err.Error(), Message: "invalid json request"})
 	}
 
 	ctx.GetSpan().SetAttributes(attribute.Int("count", req.Count()))
@@ -112,7 +112,7 @@ func DeleteHandler(c echo.Context) error {
 	histogram := ctx.Histogram("push_queue_delete_handler", context.LatencyBuckets, StatusLabel, "", AgentLabel, "")
 	if err != nil {
 		histogram.Label(StatusLabel, StatusAgentError).Since(start)
-		return c.JSON(http.StatusBadRequest, api.HTTPError{Error: err.Error(), Message: "invalid json request"})
+		return c.JSON(http.StatusBadRequest, api.HTTPError{Err: err.Error(), Message: "invalid json request"})
 	}
 
 	ctx.GetSpan().SetAttributes(attribute.String("action", "delete"), attribute.Int("upstream.push.msg-count", req.Count()))
@@ -124,7 +124,7 @@ func DeleteHandler(c echo.Context) error {
 	ctx.Logger.V(3).Infof("Deleting push data %s", req.String())
 	if err := DeleteOnUpstream(ctx, &req); err != nil {
 		histogram.Label(StatusLabel, "error").Since(start)
-		return c.JSON(http.StatusInternalServerError, api.HTTPError{Error: err.Error(), Message: "failed to upsert upstream message"})
+		return c.JSON(http.StatusInternalServerError, api.HTTPError{Err: err.Error(), Message: "failed to upsert upstream message"})
 	}
 
 	histogram.Label(StatusLabel, StatusOK).Since(start)

--- a/upstream/jobs.go
+++ b/upstream/jobs.go
@@ -102,13 +102,13 @@ func reconcileTable(ctx context.Context, config UpstreamConfig, table pushableTa
 		ctx.Tracef("pushing %s %d to upstream", table.TableName(), len(items))
 		pushError := client.Push(ctx, NewPushData(items))
 		if pushError != nil {
-			apiErr := api.FromError(pushError)
-			if apiErr == nil || apiErr.Data == "" {
+			httpError := api.HTTPErrorFromErr(pushError)
+			if httpError == nil || httpError.Data == "" {
 				return 0, fmt.Errorf("failed to push %s to upstream: %w", table.TableName(), pushError)
 			}
 
 			var foreignKeyErr PushFKError
-			if err := json.Unmarshal([]byte(apiErr.Data), &foreignKeyErr); err != nil {
+			if err := json.Unmarshal([]byte(httpError.Data), &foreignKeyErr); err != nil {
 				return 0, fmt.Errorf("failed to push %s to upstream (could not decode api error: %w): %w", table.TableName(), err, pushError)
 			}
 


### PR DESCRIPTION
resolves: https://github.com/flanksource/duty/issues/828

Upstream was sending `api.HttpError` but we were unmarshalling to `api.Error`