### PR TITLE
fix: handle composite primary key when deleting relationships

### DIFF
--- a/models/components.go
+++ b/models/components.go
@@ -532,9 +532,9 @@ func (p Properties) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 }
 
 type ComponentRelationship struct {
-	ComponentID      uuid.UUID  `json:"component_id,omitempty"`
-	RelationshipID   uuid.UUID  `json:"relationship_id,omitempty"`
-	SelectorID       string     `json:"selector_id,omitempty"`
+	ComponentID      uuid.UUID  `json:"component_id,omitempty" gorm:"primaryKey"`
+	RelationshipID   uuid.UUID  `json:"relationship_id,omitempty" gorm:"primaryKey"`
+	SelectorID       string     `json:"selector_id,omitempty" gorm:"primaryKey"`
 	RelationshipPath string     `json:"relationship_path,omitempty"`
 	CreatedAt        time.Time  `json:"created_at,omitempty"`
 	UpdatedAt        time.Time  `json:"updated_at,omitempty" gorm:"autoUpdateTime:false"`
@@ -590,8 +590,8 @@ func (ComponentRelationship) TableName() string {
 }
 
 type ConfigComponentRelationship struct {
-	ComponentID uuid.UUID  `json:"component_id,omitempty"`
-	ConfigID    uuid.UUID  `json:"config_id,omitempty"`
+	ComponentID uuid.UUID  `json:"component_id,omitempty" gorm:"primaryKey"`
+	ConfigID    uuid.UUID  `json:"config_id,omitempty" gorm:"primaryKey"`
 	SelectorID  string     `json:"selector_id,omitempty"`
 	CreatedAt   time.Time  `json:"created_at,omitempty"`
 	UpdatedAt   *time.Time `json:"updated_at,omitempty" gorm:"autoUpdateTime:false"`

--- a/models/config.go
+++ b/models/config.go
@@ -317,9 +317,9 @@ func (cs *ConfigScraper) BeforeCreate(tx *gorm.DB) error {
 }
 
 type ConfigRelationship struct {
-	ConfigID   string     `json:"config_id"`
-	RelatedID  string     `json:"related_id"`
-	Relation   string     `json:"relation"`
+	ConfigID   string     `json:"config_id" gorm:"primaryKey"`
+	RelatedID  string     `json:"related_id" gorm:"primaryKey"`
+	Relation   string     `json:"relation" gorm:"primaryKey"`
 	SelectorID string     `json:"selector_id"`
 	CreatedAt  time.Time  `json:"created_at,omitempty"`
 	UpdatedAt  time.Time  `json:"updated_at,omitempty" gorm:"autoUpdateTime:false"`

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -124,7 +124,7 @@ func DeleteHandler(c echo.Context) error {
 	ctx.Logger.V(3).Infof("Deleting push data %s", req.String())
 	if err := DeleteOnUpstream(ctx, &req); err != nil {
 		histogram.Label(StatusLabel, "error").Since(start)
-		return c.JSON(http.StatusInternalServerError, api.HTTPError{Err: err.Error(), Message: "failed to upsert upstream message"})
+		return c.JSON(http.StatusInternalServerError, api.HTTPError{Err: err.Error(), Message: "failed to delete items"})
 	}
 
 	histogram.Label(StatusLabel, StatusOK).Since(start)


### PR DESCRIPTION
resolves: https://github.com/flanksource/duty/issues/807
resolves: https://github.com/flanksource/duty/issues/834

By setting the gorm struct tags, gorm handles the `WHERE` clause.