### PR TITLE
feat: add a new handler to expose cron entries

### DIFF
--- a/job/controllers.go
+++ b/job/controllers.go
@@ -1,0 +1,50 @@
+package job
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/robfig/cron/v3"
+	"github.com/samber/lo"
+)
+
+type JobCronEntry struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Schedule     string    `json:"schedule"`
+	ResourceID   string    `json:"resource_id,omitempty"`
+	ResourceType string    `json:"resource_type,omitempty"`
+	LastRan      time.Time `json:"last_ran,omitempty"`
+	NextRun      time.Time `json:"next_run"`
+	NextRunIn    string    `json:"next_run_in"`
+}
+
+func CronDetailsHandler(crons ...*cron.Cron) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		var entries []cron.Entry
+		for i := range crons {
+			entries = append(entries, crons[i].Entries()...)
+		}
+
+		mapped := lo.Map(entries, func(e cron.Entry, _ int) JobCronEntry {
+			j, ok := e.Job.(*Job)
+			if !ok {
+				return JobCronEntry{}
+			}
+
+			return JobCronEntry{
+				ID:           j.ID,
+				ResourceID:   j.ResourceID,
+				ResourceType: j.ResourceType,
+				Name:         j.Name,
+				Schedule:     j.Schedule,
+				LastRan:      e.Prev,
+				NextRun:      e.Next,
+				NextRunIn:    time.Until(e.Next).String(),
+			}
+		})
+
+		return c.JSON(http.StatusOK, mapped)
+	}
+}


### PR DESCRIPTION
```json
[
  {
    "id": "default/localhost",
    "name": "Canary",
    "schedule": "@every 30s",
    "resource_id": "08cc3286-c0fb-479c-a0ca-8c4c6ae3181f",
    "resource_type": "canary",
    "last_ran": "0001-01-01T00:00:00Z",
    "next_run": "2024-06-18T18:41:05+05:45",
    "next_run_in": "21.701406407s"
  },
  {
    "id": "default/adityathebe.com",
    "name": "Canary",
    "schedule": "@every 30s",
    "resource_id": "21720f2f-3e85-4480-a81a-f8240bdce8f7",
    "resource_type": "canary",
    "last_ran": "0001-01-01T00:00:00Z",
    "next_run": "2024-06-18T18:41:05+05:45",
    "next_run_in": "21.701401688s"
  },
  {
    "id": "default/pod-exit-code-check",
    "name": "Canary",
    "schedule": "@every 1m",
    "resource_id": "a28245c8-b53c-4ecf-98da-47c2c6b80dec",
    "resource_type": "canary",
    "last_ran": "0001-01-01T00:00:00Z",
    "next_run": "2024-06-18T18:41:35+05:45",
    "next_run_in": "51.701400404s"
  },
  {
    "id": "",
    "name": "RefreshCheckStatusSummary",
    "schedule": "@every 1m",
    "last_ran": "0001-01-01T00:00:00Z",
    "next_run": "2024-06-18T18:41:35+05:45",
    "next_run_in": "51.701399387s"
  },
  {
    "id": "",
    "name": "ComponentStatusSummarySync",
    "schedule": "@every 2m",
    "last_ran": "0001-01-01T00:00:00Z",
    "next_run": "2024-06-18T18:42:35+05:45",
    "next_run_in": "1m51.701398425s"
  }
]

```