### PR TITLE
fix: resource selectable

### DIFF
--- a/models/checks.go
+++ b/models/checks.go
@@ -120,8 +120,8 @@ func (c Check) GetType() string {
 	return c.Type
 }
 
-func (c Check) GetStatus() string {
-	return string(c.Status)
+func (c Check) GetStatus() (string, error) {
+	return string(c.Status), nil
 }
 
 func (c Check) GetLabelsMatcher() labels.Labels {

--- a/models/config.go
+++ b/models/config.go
@@ -214,11 +214,11 @@ func (c ConfigItem) GetType() string {
 	return *c.Type
 }
 
-func (c ConfigItem) GetStatus() string {
+func (c ConfigItem) GetStatus() (string, error) {
 	if c.Status == nil {
-		return ""
+		return "", nil
 	}
-	return *c.Status
+	return *c.Status, nil
 }
 
 func (c ConfigItem) GetTagsMatcher() labels.Labels {

--- a/types/resource_selector.go
+++ b/types/resource_selector.go
@@ -104,7 +104,11 @@ func (rs ResourceSelector) Matches(s ResourceSelectable) bool {
 	if len(rs.Types) > 0 && !rs.Types.Contains(s.GetType()) {
 		return false
 	}
-	if len(rs.Statuses) > 0 && !rs.Statuses.Contains(s.GetStatus()) {
+
+	if status, err := s.GetStatus(); err != nil {
+		logger.Errorf("failed to get status: %v", err)
+		return false
+	} else if len(rs.Statuses) > 0 && !rs.Statuses.Contains(status) {
 		return false
 	}
 
@@ -187,5 +191,5 @@ type ResourceSelectable interface {
 	GetName() string
 	GetNamespace() string
 	GetType() string
-	GetStatus() string
+	GetStatus() (string, error)
 }


### PR DESCRIPTION
changed the func signature for `GetStatus()` as component status can now return err