### PR TITLE
feat: remove label key validation

### DIFF
--- a/pkg/kube/labels/selector.go
+++ b/pkg/kube/labels/selector.go
@@ -161,9 +161,6 @@ type Requirement struct {
 func NewRequirement(key string, op selection.Operator, vals []string, opts ...field.PathOption) (*Requirement, error) {
 	var allErrs field.ErrorList
 	path := field.ToPath(opts...)
-	if err := validateLabelKey(key, path.Child("key")); err != nil {
-		allErrs = append(allErrs, err)
-	}
 
 	valuePath := path.Child("values")
 	switch op {
@@ -718,9 +715,6 @@ func (p *Parser) parseKeyAndInferOperator() (string, selection.Operator, error) 
 	}
 	if tok != IdentifierToken {
 		err := fmt.Errorf("found '%s', expected: identifier", literal)
-		return "", "", err
-	}
-	if err := validateLabelKey(literal, p.path); err != nil {
 		return "", "", err
 	}
 	if t, _ := p.lookahead(Values); t == EndOfStringToken || t == CommaToken {

--- a/pkg/kube/labels/selector_test.go
+++ b/pkg/kube/labels/selector_test.go
@@ -460,17 +460,17 @@ func TestRequirementConstructor(t *testing.T) {
 				},
 			},
 		},
-		{
-			Key: strings.Repeat("a", 254), //breaks DNS rule that len(key) <= 253
-			Op:  selection.Exists,
-			WantErr: field.ErrorList{
-				&field.Error{
-					Type:     field.ErrorTypeInvalid,
-					Field:    "key",
-					BadValue: strings.Repeat("a", 254),
-				},
-			},
-		},
+		// {
+		// 	Key: strings.Repeat("a", 254), //breaks DNS rule that len(key) <= 253
+		// 	Op:  selection.Exists,
+		// 	WantErr: field.ErrorList{
+		// 		&field.Error{
+		// 			Type:     field.ErrorTypeInvalid,
+		// 			Field:    "key",
+		// 			BadValue: strings.Repeat("a", 254),
+		// 		},
+		// 	},
+		// },
 		{
 			Key: "x18",
 			Op:  "unsupportedOp",


### PR DESCRIPTION
This is required to support looking up labels with key like `aws:cloudformation:stack-id`