### PR TITLE
fix: use job struct instead of cron.FuncJob

### DIFF
--- a/tests/job_test.go
+++ b/tests/job_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Job", Ordered, func() {
 		_ = context.UpdateProperty(ctx, "test.trace", "true")
 		_ = context.UpdateProperty(ctx, "test.db.level", "trace")
 		_ = context.UpdateProperty(ctx, "job.eviction.period", "1s")
+		_ = context.UpdateProperty(ctx, "job.jitter.disable", "true")
 
 		sampleJob.Run()
 		Expect(sampleJob.Retention.Success).To(Equal(1))


### PR DESCRIPTION
canary-checker needs the cron entries to be `cron.Job` instead of `cron.FuncJob` so it can extract the resource ID.