### PR TITLE
fix: topology view

### DIFF
--- a/hack/migrate/main.go
+++ b/hack/migrate/main.go
@@ -13,6 +13,7 @@ var migrate = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := duty.Migrate(api.Config{
 			ConnectionString: connection,
+			Postgrest:        api.DefaultConfig.Postgrest,
 		}); err != nil {
 			logger.Fatalf(err.Error())
 		}

--- a/views/010_topology.sql
+++ b/views/010_topology.sql
@@ -11,6 +11,7 @@ $$ LANGUAGE plpgsql;
 
 -- Drop these first because of dependencies
 DROP VIEW IF EXISTS topology;
+
 DROP VIEW IF EXISTS check_summary_by_component;
 
 DROP VIEW IF EXISTS checks_by_component;


### PR DESCRIPTION
resolves: failed to query rest of the children: ERROR: column "health_expr" does not exist (SQLSTATE 42703)

`health_expr` exists however the topology view needs to be recreated.

A small diff on the migration file should trigger the run.