### PR TITLE
fix: handle `NULL` paths when reconciling `config_items`

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -141,7 +141,7 @@ func (t ConfigItem) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) error {
 
 func (t ConfigItem) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 	var items []ConfigItem
-	err := db.Where("is_pushed IS FALSE").Order("length(path)").Find(&items).Error
+	err := db.Where("is_pushed IS FALSE").Order("LENGTH(COALESCE(path, ''))").Find(&items).Error
 	return lo.Map(items, func(i ConfigItem, _ int) DBTable { return i }), err
 }
 


### PR DESCRIPTION
root config_items have `NULL` path. When ordering by `LENGTH(path) ASC` they appear at the end.
so we try to reconcile the children first and always hit foreign key error.