### PR TITLE
fix: change on conflict clause order

### DIFF
--- a/models/components.go
+++ b/models/components.go
@@ -334,7 +334,7 @@ func (c *Component) Save(db *gorm.DB) error {
 	}
 	err := db.Clauses(
 		clause.OnConflict{
-			Columns:   []clause.Column{{Name: "topology_id"}, {Name: "name"}, {Name: "type"}, {Name: "parent_id"}},
+			Columns:   []clause.Column{{Name: "topology_id"}, {Name: "type"}, {Name: "name"}, {Name: "parent_id"}},
 			UpdateAll: true,
 		},
 		clause.OnConflict{


### PR DESCRIPTION
We are getting this error while pushing topologies
```
error pushing topology: error pushing topology[Tenant/org-86mkxfst1do7/t-test1] to https://telemetry.app.flanksource.com/push/topology, non 2xx response received: 500 Internal Server Error
{"error":"error saving components: ERROR: duplicate key value violates unique constraint 
\"components_topology_id_type_name_parent_id_key\" (SQLSTATE 23505): detail: Key (topology_id, type, name, 
parent_id)=(0be593be-3d79-406b-8168-224b20efb83b, JobHistory, AggregateCheckStatuses1d, 018fe70b-3927-e69e-
f8ab-328d78f75547) already exists."} 
```
Although the unique clause exists, the order is different

I tried locally and order should not matter but still doing this anyway