### PR TITLE
fix: use single on conflict clause

### DIFF
--- a/models/components.go
+++ b/models/components.go
@@ -337,10 +337,6 @@ func (c *Component) Save(db *gorm.DB) error {
 			Columns:   []clause.Column{{Name: "topology_id"}, {Name: "type"}, {Name: "name"}, {Name: "parent_id"}},
 			UpdateAll: true,
 		},
-		clause.OnConflict{
-			Columns:   []clause.Column{{Name: "id"}},
-			UpdateAll: true,
-		},
 	).Create(c).Error
 
 	if err != nil {

--- a/models/topology.go
+++ b/models/topology.go
@@ -60,11 +60,6 @@ func (t *Topology) AsMap(removeFields ...string) map[string]any {
 }
 
 func (t *Topology) Save(db *gorm.DB) error {
-	err := db.Clauses(Topology{}.OnConflictClause(),
-		clause.OnConflict{
-			Columns:   []clause.Column{{Name: "id"}},
-			DoUpdates: clause.AssignmentColumns([]string{"labels", "spec"}),
-		},
-	).Create(t).Error
+	err := db.Clauses(Topology{}.OnConflictClause()).Create(t).Error
 	return err
 }


### PR DESCRIPTION
PostgreSQL does not support multiple on conflict
The OnConflict was added on ID to handle pushed topology saves but we don't really need it