### PR TITLE
fix: add health to component topology select clause

### DIFF
--- a/query/topology.go
+++ b/query/topology.go
@@ -33,7 +33,7 @@ func (opt TopologyOptions) selectClause() string {
 	}
 
 	// parents & (incidents, analysis, checks) columns need to fetched to create the topology tree even though they may not be essential to the UI.
-	return "name, namespace, id, is_leaf, status, status_expr, health_expr, status_reason, icon, summary, topology_type, labels, team_names, type, parent_id, parents, incidents, analysis, checks"
+	return "name, namespace, id, is_leaf, status, status_expr, health, health_expr, status_reason, icon, summary, topology_type, labels, team_names, type, parent_id, parents, incidents, analysis, checks"
 }
 
 func (opt TopologyOptions) componentWhereClause() string {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2143