### PR TITLE
fix: remove agent_id from playbook runs table

### DIFF
--- a/models/playbooks.go
+++ b/models/playbooks.go
@@ -126,7 +126,6 @@ type PlaybookRun struct {
 	Error         *string             `json:"error,omitempty"`
 	Parameters    types.JSONStringMap `json:"parameters,omitempty" gorm:"default:null"`
 	Request       types.JSONMap       `json:"request,omitempty" gorm:"default:null"`
-	AgentID       *uuid.UUID          `json:"agent_id,omitempty"`
 }
 
 func (p PlaybookRun) TableName() string {

--- a/schema/playbooks.hcl
+++ b/schema/playbooks.hcl
@@ -184,11 +184,6 @@ table "playbook_runs" {
     null = true
     type = jsonb
   }
-  column "agent_id" {
-    null    = true
-    default = var.uuid_nil
-    type    = uuid
-  }
   column "error" {
     null = true
     type = text
@@ -223,12 +218,6 @@ table "playbook_runs" {
   foreign_key "playbook_run_component_id_fkey" {
     columns     = [column.component_id]
     ref_columns = [table.components.column.id]
-    on_update   = NO_ACTION
-    on_delete   = NO_ACTION
-  }
-  foreign_key "playbook_run_agent_id_fkey" {
-    columns     = [column.agent_id]
-    ref_columns = [table.agents.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
@@ -338,7 +327,10 @@ table "playbook_run_actions" {
     EOF
     comment = "a run id is mandatory except for an agent"
   }
-
+  index "playbook_run_actions_name" {
+    unique = true
+    columns = [column.playbook_run_id, column.name]
+  }
   index "playbook_run_actions_status_time_idx" {
     columns = [column.status, column.scheduled_time]
   }

--- a/views/022_agents.sql
+++ b/views/022_agents.sql
@@ -6,7 +6,7 @@ SELECT
     configs.count as config_count,
     config_scrapper.count as config_scrapper_count,
     checks.count as checks_count,
-    playbook_runs.count as playbook_runs_count
+    playbook_run_actions.count as playbook_run_actions_count
 FROM
     agents
     LEFT JOIN (
@@ -41,10 +41,10 @@ FROM
             agent_id,
             COUNT(id) as count
         FROM
-            playbook_runs
+            playbook_run_actions
         GROUP BY
             agent_id
-    ) AS playbook_runs ON playbook_runs.agent_id = agents.id
+    ) AS playbook_run_actions ON playbook_run_actions.agent_id = agents.id
 WHERE
   deleted_at IS NULL;
 


### PR DESCRIPTION
The runs do not need agent id. They are always local and orchestrated by the local agent.

It's the actions that need the agent id.