### PR TITLE
fix: reconcile error handling

### DIFF
--- a/types/common.go
+++ b/types/common.go
@@ -135,3 +135,16 @@ func (items Items) Where(query *gorm.DB, col string) *gorm.DB {
 
 	return query
 }
+
+// ErrorString wraps the error to implement custom JSON marshaling
+type ErrorString struct {
+	Err error
+}
+
+// Convert the error to its string representation if non-nil, else return an empty string.
+func (e ErrorString) MarshalJSON() ([]byte, error) {
+	if e.Err != nil {
+		return json.Marshal(e.Err.Error())
+	}
+	return json.Marshal("")
+}

--- a/types/common.go
+++ b/types/common.go
@@ -135,16 +135,3 @@ func (items Items) Where(query *gorm.DB, col string) *gorm.DB {
 
 	return query
 }
-
-// ErrorString wraps the error to implement custom JSON marshaling
-type ErrorString struct {
-	Err error
-}
-
-// Convert the error to its string representation if non-nil, else return an empty string.
-func (e ErrorString) MarshalJSON() ([]byte, error) {
-	if e.Err != nil {
-		return json.Marshal(e.Err.Error())
-	}
-	return json.Marshal("")
-}


### PR DESCRIPTION
We were getting empty errors as `json.Marshal` always marshals `error` type as `{}` due to it being an interface

To do: Also if summary.Error is non nil, job history returns success since we do not update error count, this needs to be fixed in mission-control

Have fixed this, but UI is now having an issue rendering it
![image](https://github.com/user-attachments/assets/b58e724e-0026-4cdf-85e6-aa4e6d8cd8a1)

Error details:
```json
{
  "errors": "job_history: failed to push job_history to upstream: upstream server returned error status[500]: Internal Server Error; ",
  "summary": {
    "checks": {
      "success": 25
    },
    "components": {
      "success": 103
    },
    "job_history": {
      "error": "failed to push job_history to upstream: upstream server returned error status[500]: Internal Server Error"
    },
    "config_items": {
      "success": 28
    },
    "check_statuses": {
      "success": 81
    },
    "config_changes": {
      "success": 35
    },
    "config_relationships": {
      "success": 12
    },
    "component_relationships": {
      "success": 3
    },
    "config_component_relationships": {
      "success": 1
    }
  }
}
```
