### PR TITLE
fix: start job history channel fetch before adding items

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -39,7 +39,21 @@ const (
 	maxJitterDuration = time.Minute * 15
 )
 
-var EvictedJobs chan uuid.UUID
+var (
+	EvictedJobs       chan uuid.UUID
+	startedJobHistory = false
+)
+
+func StartJobHistoryEvictor(ctx context.Context) {
+	if !startedJobHistory {
+		if EvictedJobs == nil {
+			EvictedJobs = make(chan uuid.UUID, 1000)
+		}
+		go deleteEvictedJobs(ctx)
+		startedJobHistory = true
+	}
+
+}
 
 // deleteEvictedJobs deletes job_history rows from the DB every job.eviction.period(1m),
 // jobs send rows to be deleted by maintaining a circular buffer by status type

--- a/job/job.go
+++ b/job/job.go
@@ -456,10 +456,7 @@ func (j *Job) GetPropertyInt(property string, def int) int {
 }
 
 func (j *Job) init() error {
-	if EvictedJobs == nil {
-		EvictedJobs = make(chan uuid.UUID, 1000)
-		go deleteEvictedJobs(j.Context)
-	}
+	StartJobHistoryEvictor(j.Context)
 
 	if j.initialized {
 		return nil
@@ -636,4 +633,10 @@ func (j *Job) RemoveFromScheduler(cronRunner *cron.Cron) {
 		return
 	}
 	cronRunner.Remove(*j.entryID)
+}
+
+func init() {
+	if EvictedJobs == nil {
+		EvictedJobs = make(chan uuid.UUID, 1000)
+	}
 }

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/job"
 	"github.com/flanksource/duty/models"
 	"github.com/labstack/echo/v4"
 	"github.com/patrickmn/go-cache"
@@ -112,6 +113,7 @@ func addJobHistoryToRing(ctx context.Context, agentID string, histories []models
 	if ringManager == nil {
 		return
 	}
+	job.StartJobHistoryEvictor(ctx)
 
 	for _, history := range histories {
 		ringManager.Add(ctx, agentID, history)


### PR DESCRIPTION
It wasn't working correctly since we were passing an uninitialized channel which is nil and does not get passed by reference.

The main issue was that we were adding items to an always uninitialized channel and that was blocking the whole operation