### PR TITLE
fix: remove old lookup_component_config_id_related_components func signature

### DIFF
--- a/views/005_component_views.sql
+++ b/views/005_component_views.sql
@@ -130,8 +130,7 @@ BEGIN
 END;
 $$ language plpgsql;
 
-DROP FUNCTION if exists lookup_component_relations;
-
+DROP FUNCTION IF EXISTS lookup_component_relations;
 CREATE OR REPLACE FUNCTION lookup_component_relations (component_id text)
 RETURNS TABLE (id UUID) AS $$
 BEGIN
@@ -146,6 +145,7 @@ CREATE OR REPLACE VIEW component_types AS
   SELECT distinct on (type) type
   FROM components ORDER BY type asc;
 
+DROP FUNCTION IF EXISTS lookup_component_config_id_related_components;
 CREATE OR REPLACE FUNCTION lookup_component_config_id_related_components (
   component_id TEXT
 )


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2203