### PR TITLE
feat: allow namespace/name for scope in resource selector

### DIFF
--- a/query/getters.go
+++ b/query/getters.go
@@ -17,6 +17,8 @@ var (
 	getterCache = cache.New(time.Second*90, time.Minute*5)
 
 	immutableCache = cache.New(cache.NoExpiration, time.Hour*12)
+
+	scopeCache = cache.New(time.Hour, time.Hour*2)
 )
 
 func FlushGettersCache() {

--- a/types/resource_selector.go
+++ b/types/resource_selector.go
@@ -33,10 +33,11 @@ type ResourceSelector struct {
 	//  Additionally, the special "self" value can be used to select resources without an agent.
 	Agent string `yaml:"agent,omitempty" json:"agent,omitempty"`
 
-	// Scope is the id parent of the resource to select.
-	// Example: For config items, the scope is the scraper id
-	// - for checks, it's canaries and
-	// - for components, it's topology.
+	// Scope is the reference for parent of the resource to select.
+	// For config items, the scope is the scraper id
+	// For checks, it's canaries and
+	// For components, it's topology.
+	// It can either be a uuid or namespace/name
 	Scope string `yaml:"scope,omitempty" json:"scope,omitempty"`
 
 	// Cache directives


### PR DESCRIPTION
For using catalog lookup in k8s topology chart, we need to be able to distinguish b/w clusters, currently we do that via kubeconfig using kubernetes lookup.

We need to allow scope to be selectable by namespace/name to have the same functionality