### PR TITLE
fix: concat config_id and path for lookup_component_config_query

### DIFF
--- a/views/005_component_views.sql
+++ b/views/005_component_views.sql
@@ -155,7 +155,7 @@ BEGIN
         WITH config_id_paths AS (
             SELECT config_items.id
             FROM config_items
-            WHERE starts_with(path, (SELECT path FROM config_items WHERE config_items.id IN (SELECT config_id FROM components WHERE components.id = $1::UUID)))
+            WHERE starts_with(path, (SELECT CONCAT(path, '.', id) FROM config_items WHERE config_items.id IN (SELECT config_id FROM components WHERE components.id = $1::UUID)))
         )
         SELECT components.id 
         FROM components 


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control-registry/issues/321