### PR TITLE
fix: undo drop of playbook_run_status

### DIFF
--- a/schema/playbooks.hcl
+++ b/schema/playbooks.hcl
@@ -119,6 +119,11 @@ table "playbook_approvals" {
   comment = "Keeps track of approvals on a playbook run"
 }
 
+enum "playbook_run_status" {
+  schema = schema.public
+  values = ["scheduled", "running", "cancelled", "completed", "failed", "pending", "sleeping"]
+}
+
 table "playbook_runs" {
   schema = schema.public
   column "id" {


### PR DESCRIPTION
Error on aws
```json
{"time":"2024-10-16T04:15:52.308735642Z","level":"ERROR+1","msg":"failed to apply schema migrations: applied 6 changes and then failed: drop enum type \"playbook_run_status\": pq: cannot drop type playbook_run_status because other objects depend on it"}
```

Seems like migration does not update column types ? we dont use that type anywhere but getting this from db
```sql
mission_control=# SELECT                                                                                     
    table_schema,
    table_name,
    column_name
FROM
    information_schema.columns
WHERE
    column_default LIKE '%playbook_run_status%';

-[ RECORD 1 ]+---------------------
table_schema | public
table_name   | playbook_run_actions
column_name  | status
```

Also, we should update the tool's version ? we are on a year old release and a new stable release was dropped 2 weeks ago, they added trigger support and function support as well