### PR TITLE
chore: trim space/newline around connection username,password and url

### DIFF
--- a/context/connection.go
+++ b/context/connection.go
@@ -231,6 +231,11 @@ func HydrateConnection(ctx Context, connection *models.Connection) (*models.Conn
 		}
 	}
 
+	// Remove newlines and spaces around username,password & url
+	connection.URL = strings.TrimSpace(connection.URL)
+	connection.Username = strings.TrimSpace(connection.Username)
+	connection.Password = strings.TrimSpace(connection.Password)
+
 	domain := ""
 	parts := strings.Split(connection.Username, "@")
 	if len(parts) == 2 {

--- a/context/connection_test.go
+++ b/context/connection_test.go
@@ -124,6 +124,24 @@ var _ = ginkgo.Describe("Connection Tests", func() {
 				},
 				expect: "postgres://the-username:the-password@localhost:5443/mission_control",
 			},
+			{
+				name: "space and newline trimming",
+				connection: models.Connection{
+					URL: `
+
+                        postgres://$(username):$(password)@$(properties.host):$(properties.port)/$(properties.database)
+
+                    `,
+					Username: "  the-username",
+					Password: "the-password  ",
+					Properties: map[string]string{
+						"host":     "localhost",
+						"database": "mission_control",
+						"port":     "5443",
+					},
+				},
+				expect: "postgres://the-username:the-password@localhost:5443/mission_control",
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/duty/issues/941