### PR TITLE
feat: improve event consumers

### DIFF
--- a/postq/pg_consumer.go
+++ b/postq/pg_consumer.go
@@ -65,7 +65,6 @@ func NewPGConsumer(consumerFunc ConsumerFunc, opt *ConsumerOption) (*PGConsumer,
 		if opt.ErrorHandler != nil {
 			ec.errorHandler = opt.ErrorHandler
 		}
-
 	}
 
 	return ec, nil


### PR DESCRIPTION
discard unnecessary pgnotify notifications.

For every event we're currently calling `ConsumeUntilEmpty`. 
If 10 events are published in burst, we call `ConsumeUntilEmpty` for each of those 10 notifications.

This PR fixes that behavior by simply discarding additional signals.