### PR TITLE
fix: bring back notification_send_history_summary

### DIFF
--- a/views/021_notification.sql
+++ b/views/021_notification.sql
@@ -115,4 +115,4 @@ UNION
   ) canary ON canary.id = nsh.resource_id
   WHERE nsh.source_event like 'canary.%'
 )
-SELECT combined.* FROM combined
+SELECT combined.* FROM combined;


### PR DESCRIPTION
a superfluous change in the file to run it during migration.

```
{
    "code": "42P01",
    "details": null,
    "hint": null,
    "message": "relation \"public.notification_send_history_summary\" does not exist"
}
```

resolves: https://github.com/flanksource/mission-control/issues/1548