### PR TITLE
fix: do not create change for new items with unknown health

### DIFF
--- a/views/029_config_triggers.sql
+++ b/views/029_config_triggers.sql
@@ -30,7 +30,7 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  IF OLD.health = NEW.health OR (OLD.health IS NULL AND NEW.health IS NULL) THEN
+  IF OLD.health = NEW.health OR (OLD.health IS NULL AND NEW.health IS NULL) OR (OLD IS NULL AND NEW.health = 'unknown') THEN
     RETURN NULL;
   END IF;
 


### PR DESCRIPTION
Causing a few config-db test cases to break, and I don't think we need to create a change event for newly created items