### PR TITLE
chore: refactor kubernetes client constructor

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -346,25 +346,18 @@ func (k *Context) WithKubeconfig(input types.EnvVar) (*Context, error) {
 	if k.GetNamespace() == "" {
 		return nil, k.Oops().Errorf("namespace is required")
 	}
+
 	val, err := k.GetEnvValueFromCache(input, k.GetNamespace())
 	if err != nil {
 		return k, k.Oops().Wrap(err)
 	}
 
-	var client kubernetes.Interface
-	var rest *rest.Config
-
-	if strings.HasPrefix(val, "/") {
-		if client, rest, err = dutyKubernetes.NewClient(k.Logger, val); err != nil {
-			return k, k.Oops().Wrap(err)
-		}
-	} else {
-		if client, rest, err = dutyKubernetes.NewClientWithConfig(k.Logger, []byte(val)); err != nil {
-			return k, k.Oops().Wrap(err)
-		}
+	clientset, restConfig, err := dutyKubernetes.NewClientFromPathOrConfig(k.Logger, val)
+	if err != nil {
+		return k, k.Oops().Wrap(err)
 	}
 
-	c := k.WithKubernetes(client, rest)
+	c := k.WithKubernetes(clientset, restConfig)
 
 	return &c, nil
 

--- a/kubernetes/k8s.go
+++ b/kubernetes/k8s.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/flanksource/commons/console"
@@ -98,6 +99,24 @@ func NewClientWithConfig(logger logger.Logger, kubeConfig []byte) (kubernetes.In
 		client, err := kubernetes.NewForConfig(trace(logger, config))
 		return cacheResult(string(kubeConfig), client, config, err)
 	}
+}
+
+func NewClientFromPathOrConfig(logger logger.Logger, kubeconfigOrPath string) (kubernetes.Interface, *rest.Config, error) {
+	var client kubernetes.Interface
+	var rest *rest.Config
+	var err error
+
+	if strings.HasPrefix(kubeconfigOrPath, "/") {
+		if client, rest, err = NewClient(logger, kubeconfigOrPath); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		if client, rest, err = NewClientWithConfig(logger, []byte(kubeconfigOrPath)); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return client, rest, err
 }
 
 func trace(clogger logger.Logger, config *rest.Config) *rest.Config {


### PR DESCRIPTION
adds `NewClientFromPathOrConfig` so the caller doesn't have to check if the config is kubeconfig path or the actual kubeconfig.