### PR TITLE
fix: don't call os.Exit() on tests

### DIFF
--- a/tests/migration_dependency_test.go
+++ b/tests/migration_dependency_test.go
@@ -33,7 +33,7 @@ var _ = Describe("migration dependency", Ordered, func() {
 		funcs, views, err := migrate.GetExecutableScripts(db, []string{"incident_ids.sql"}, nil)
 		Expect(err).To(BeNil())
 		Expect(len(funcs)).To(Equal(1))
-		Expect(len(views)).To(BeZero())
+		Expect(len(views)).To(Equal(1), "skipped RLS disable is picked up here")
 	})
 
 	It("should ignore changed hash run script", func() {
@@ -50,7 +50,7 @@ var _ = Describe("migration dependency", Ordered, func() {
 		funcs, views, err := migrate.GetExecutableScripts(db, nil, []string{"incident_ids.sql"})
 		Expect(err).To(BeNil())
 		Expect(len(funcs)).To(BeZero())
-		Expect(len(views)).To(BeZero())
+		Expect(len(views)).To(Equal(1), "skipped RLS disable is picked up here")
 
 		err = DefaultContext.DB().Exec(`UPDATE migration_logs SET hash = ? WHERE path = 'incident_ids.sql'`, []byte(currentHash)[:]).Error
 		Expect(err).To(BeNil(), "failed to restore hash for incidents_ids.sql")
@@ -63,7 +63,7 @@ var _ = Describe("migration dependency", Ordered, func() {
 		sqlDB, err := DefaultContext.DB().DB()
 		Expect(err).To(BeNil())
 
-		funcs, views, err := migrate.GetExecutableScripts(sqlDB, nil, nil)
+		funcs, views, err := migrate.GetExecutableScripts(sqlDB, nil, []string{"035_rls_disable.sql"})
 		Expect(err).To(BeNil())
 		Expect(len(funcs)).To(Equal(1))
 		Expect(len(views)).To(Equal(2))

--- a/tests/setup/common.go
+++ b/tests/setup/common.go
@@ -122,7 +122,8 @@ func findFileInPath(filename string, depth int) string {
 func BeforeSuiteFn(args ...interface{}) context.Context {
 	ctx, err := SetupDB("test", args...)
 	if err != nil {
-		shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to setup db: %v", err))
+		shutdown.Shutdown()
+		Expect(err).To(BeNil())
 	}
 
 	DefaultContext = ctx
@@ -252,7 +253,7 @@ func SetupDB(dbName string, args ...interface{}) (context.Context, error) {
 }
 
 func AfterSuiteFn() {
-	shutdown.ShutdownAndExit(0, "")
+	shutdown.Shutdown()
 }
 
 // NewDB creates a new database from an existing context, and


### PR DESCRIPTION
* test fails anyway even with exit code 0
* fix migration dependency test which was sporadically failing 