### PR TITLE
Feat/trigger for team members

### DIFF
--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -100,14 +100,14 @@ table "team_members" {
   foreign_key "team_members_person_id_fkey" {
     columns     = [column.person_id]
     ref_columns = [table.people.column.id]
-    on_update   = NO_ACTION
-    on_delete   = NO_ACTION
+    on_update   = CASCADE
+    on_delete   = CASCADE
   }
   foreign_key "team_members_team_id_fkey" {
     columns     = [column.team_id]
     ref_columns = [table.teams.column.id]
-    on_update   = NO_ACTION
-    on_delete   = NO_ACTION
+    on_update   = CASCADE
+    on_delete   = CASCADE
   }
 }
 


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/1707


* add TG_OP to the payload for `table_activity` notifications
* for notifications on `team_members` table, send both team_id and person_id instead of just the primary key like in the other tables

**TODO:**
When a team is deleted, we send pg notifications for all the members associated with the team
and another notification for the deletion of the team. For our use cases, we just need one notification _(i.e. of the team's deletion)_, so we can just exec one `DeleteRole()` call instead of `DeleteRoleForPerson()` for each members. 

