### PR TITLE
fix: sporadically failing RLS test

### DIFF
--- a/tests/migration_dependency_test.go
+++ b/tests/migration_dependency_test.go
@@ -9,11 +9,20 @@ import (
 	"github.com/flanksource/duty/migrate"
 )
 
-var _ = Describe("migration dependency", Ordered, func() {
+var _ = Describe("migration dependency", Ordered, Serial, func() {
 	var connString string
 
 	BeforeAll(func() {
 		connString = DefaultContext.Value("db_url").(string)
+	})
+
+	AfterAll(func() {
+		sqlDB, err := DefaultContext.DB().DB()
+		Expect(err).To(BeNil())
+
+		// we re-enable RLS
+		err = migrate.RunMigrations(sqlDB, api.Config{ConnectionString: connString, EnableRLS: true})
+		Expect(err).To(BeNil())
 	})
 
 	It("should have no executable scripts", func() {


### PR DESCRIPTION
```
The entire test suite is ran with RLS enabled.
One of the tests (migration dependency test) ran the migration that disabled RLS.
```