### PR TITLE
fix: resource selector cache scoped per user when RLS is enabled

### DIFF
--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -377,9 +377,9 @@ func queryResourceSelector(ctx context.Context, limit int, resourceSelector type
 
 	hash := fmt.Sprintf("%s-%s-%d", table, resourceSelector.Hash(), limit)
 
-	// NOTE: When RLS is enabled, we need to scope the cache per user.
-	if ctx.Value("rls-enabled") != nil && ctx.User() != nil {
-		hash += fmt.Sprintf("-%s", ctx.User().ID)
+	// NOTE: When RLS is enabled, we need to scope the cache per RLS permission.
+	if payload := ctx.RLSPayload(); payload != nil {
+		hash += fmt.Sprintf("-rls-%s", payload.Fingerprint())
 	}
 
 	cacheToUse := getterCache

--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -376,6 +376,12 @@ func queryResourceSelector(ctx context.Context, limit int, resourceSelector type
 	}
 
 	hash := fmt.Sprintf("%s-%s-%d", table, resourceSelector.Hash(), limit)
+
+	// NOTE: When RLS is enabled, we need to scope the cache per user.
+	if ctx.Value("rls-enabled") != nil && ctx.User() != nil {
+		hash += fmt.Sprintf("-%s", ctx.User().ID)
+	}
+
 	cacheToUse := getterCache
 	if resourceSelector.Immutable() {
 		cacheToUse = immutableCache

--- a/rls/payload.go
+++ b/rls/payload.go
@@ -1,0 +1,43 @@
+package rls
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/flanksource/commons/collections"
+)
+
+// RLS Payload that's injected postgresl parameter `request.jwt.claims`
+type Payload struct {
+	// cached fingerprint
+	fingerprint string
+
+	Tags    []map[string]string `json:"tags,omitempty"`
+	Agents  []string            `json:"agents,omitempty"`
+	Disable bool                `json:"disable_rls,omitempty"`
+}
+
+func (t *Payload) EvalFingerprint() {
+	if t.Disable {
+		t.fingerprint = "disabled"
+		return
+	}
+
+	var tagSelectors []string
+	for _, t := range t.Tags {
+		tagSelectors = append(tagSelectors, collections.SortedMap(t))
+	}
+	slices.Sort(tagSelectors)
+	slices.Sort(t.Agents)
+
+	t.fingerprint = fmt.Sprintf("%s-%s", strings.Join(t.Agents, "--"), strings.Join(tagSelectors, "--"))
+}
+
+func (t *Payload) Fingerprint() string {
+	if t.fingerprint == "" {
+		t.EvalFingerprint()
+	}
+
+	return t.fingerprint
+}

--- a/rls/payload_test.go
+++ b/rls/payload_test.go
@@ -1,0 +1,78 @@
+package rls
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestPayload_EvalFingerprint(t *testing.T) {
+	t.Run("should set fingerprint to 'disabled' if Disable is true", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		payload := &Payload{
+			Disable: true,
+		}
+		payload.EvalFingerprint()
+
+		g.Expect(payload.Fingerprint()).To(gomega.Equal("disabled"))
+	})
+
+	t.Run("should compute deterministic fingerprint for Tags and Agents", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		payload := &Payload{
+			Tags: []map[string]string{
+				{"z": "value1", "a": "value2"},
+				{"b": "value3"},
+			},
+			Agents: []string{"agent2", "agent1"},
+		}
+		payload.EvalFingerprint()
+
+		expectedFingerprint := "agent1--agent2-a=value2,z=value1--b=value3"
+		g.Expect(payload.Fingerprint()).To(gomega.Equal(expectedFingerprint))
+	})
+
+	t.Run("should compute 'empty' fingerprint for empty Tags and Agents", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		payload := &Payload{}
+		payload.EvalFingerprint()
+
+		g.Expect(payload.Fingerprint()).To(gomega.Equal("-"))
+	})
+
+	t.Run("should sort Tags and Agents deterministically", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		payload := &Payload{
+			Tags: []map[string]string{
+				{"b": "value3"},
+				{"z": "value1", "a": "value2"},
+			},
+			Agents: []string{"agent3", "agent1", "agent2"},
+		}
+		payload.EvalFingerprint()
+
+		expectedFingerprint := "agent1--agent2--agent3-a=value2,z=value1--b=value3"
+		g.Expect(payload.Fingerprint()).To(gomega.Equal(expectedFingerprint))
+	})
+
+	t.Run("should cache the fingerprint after first computation", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+
+		payload := &Payload{
+			Tags: []map[string]string{
+				{"x": "value4"},
+			},
+			Agents: []string{"agentX"},
+		}
+		payload.EvalFingerprint()
+		firstFingerprint := payload.Fingerprint()
+
+		// Modify the underlying data to see if the cached fingerprint remains unchanged
+		payload.Tags[0]["x"] = "modified_value"
+		g.Expect(payload.Fingerprint()).To(gomega.Equal(firstFingerprint))
+	})
+}


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/1750