### PR TITLE
fix: permission to casbin policy mapping

### DIFF
--- a/models/permission.go
+++ b/models/permission.go
@@ -104,7 +104,7 @@ func (t *Permission) Condition() string {
 
 	if len(t.ObjectSelector) > 0 {
 		// TODO: Find a way to pass in the JSON encoded string instead of encoding with base64
-		rule = append(rule, fmt.Sprintf(`matchResourceSelector(r.obj, %q)`, base64.StdEncoding.EncodeToString([]byte(t.ObjectSelector))))
+		rule = append(rule, fmt.Sprintf(`matchResourceSelector(r.obj, '%s')`, base64.StdEncoding.EncodeToString([]byte(t.ObjectSelector))))
 	}
 
 	if t.ComponentID != nil {
@@ -129,7 +129,7 @@ func (t *Permission) Condition() string {
 			agents = append(agents, fmt.Sprintf("'%s'", agentID))
 		}
 
-		rule = append(rule, fmt.Sprintf(`"matchPerm(r.obj, (%s), '%s')"`, strings.Join(agents, ","), collections.SortedMap(t.Tags)))
+		rule = append(rule, fmt.Sprintf(`matchPerm(r.obj, (%s), '%s')`, strings.Join(agents, ","), collections.SortedMap(t.Tags)))
 	}
 
 	return strings.Join(rule, " && ")

--- a/models/permission_test.go
+++ b/models/permission_test.go
@@ -39,7 +39,7 @@ func TestPermission_Condition(t *testing.T) {
 			perm: Permission{
 				Agents: pq.StringArray([]string{"aws", "azure"}),
 			},
-			expected: `"matchPerm(r.obj, ('aws','azure'), '')"`,
+			expected: `matchPerm(r.obj, ('aws','azure'), '')`,
 		},
 		{
 			name: "tags",
@@ -48,7 +48,7 @@ func TestPermission_Condition(t *testing.T) {
 					"cluster": "aws",
 				},
 			},
-			expected: `"matchPerm(r.obj, (), 'cluster=aws')"`,
+			expected: `matchPerm(r.obj, (), 'cluster=aws')`,
 		},
 	}
 

--- a/models/playbooks.go
+++ b/models/playbooks.go
@@ -423,10 +423,19 @@ func (p *PlaybookRun) String(db *gorm.DB) string {
 }
 
 type RBACAttribute struct {
-	Playbook  *Playbook
-	Component *Component
-	Config    *ConfigItem
-	Check     *Check
+	Playbook  Playbook   `json:"playbook"`
+	Component Component  `json:"component"`
+	Config    ConfigItem `json:"config"`
+	Check     Check      `json:"check"`
+}
+
+func (r RBACAttribute) AsMap() map[string]any {
+	return map[string]any{
+		"component": r.Component.AsMap(),
+		"config":    r.Config.AsMap(),
+		"check":     r.Check.AsMap(),
+		"playbook":  r.Playbook.AsMap(),
+	}
 }
 
 func (run *PlaybookRun) GetRBACAttributes(db *gorm.DB) (*RBACAttribute, error) {
@@ -436,14 +445,14 @@ func (run *PlaybookRun) GetRBACAttributes(db *gorm.DB) (*RBACAttribute, error) {
 	if err := db.First(&playbook, run.PlaybookID).Error; err != nil {
 		return nil, err
 	}
-	output.Playbook = &playbook
+	output.Playbook = playbook
 
 	if run.ComponentID != nil {
 		var component Component
 		if err := db.First(&component, run.ComponentID).Error; err != nil {
 			return nil, err
 		}
-		output.Component = &component
+		output.Component = component
 	}
 
 	if run.CheckID != nil {
@@ -451,7 +460,7 @@ func (run *PlaybookRun) GetRBACAttributes(db *gorm.DB) (*RBACAttribute, error) {
 		if err := db.First(&check, run.CheckID).Error; err != nil {
 			return nil, err
 		}
-		output.Check = &check
+		output.Check = check
 	}
 
 	if run.ConfigID != nil {
@@ -459,7 +468,7 @@ func (run *PlaybookRun) GetRBACAttributes(db *gorm.DB) (*RBACAttribute, error) {
 		if err := db.First(&config, run.ConfigID).Error; err != nil {
 			return nil, err
 		}
-		output.Config = &config
+		output.Config = config
 	}
 
 	return &output, nil


### PR DESCRIPTION
The condition on the policy shouldn't be using double quotes.

Add `.AsMap()` to `RBACAttribute`.
When `RBACAttribute` object was directly passed to casbin, it returned the following error

```
Unable to access unexported field 'playbook' in 'r_obj'
```

This happend despite the fact that the struct and the fields were exported and also the fields had json tags.