### PR TITLE
fix: Don't serialize ABAC attributes. Use the object directly inside casbin

### DIFF
--- a/models/common.go
+++ b/models/common.go
@@ -156,3 +156,13 @@ func (c genericFieldMatcher) Has(key string) bool {
 	_, ok := c.Fields[key]
 	return ok
 }
+
+// ABACAttribute is the object passed to casbin for authorization checks.
+//
+// NOTE: the fields are not a pointer to avoid nil pointer checks in the casbin policy.
+type ABACAttribute struct {
+	Playbook  Playbook
+	Component Component
+	Config    ConfigItem
+	Check     Check
+}

--- a/models/permission.go
+++ b/models/permission.go
@@ -108,19 +108,19 @@ func (t *Permission) Condition() string {
 	}
 
 	if t.ComponentID != nil {
-		rule = append(rule, fmt.Sprintf("r.obj.component.id == %q", t.ComponentID.String()))
+		rule = append(rule, fmt.Sprintf("r.obj.Component.ID == %q", t.ComponentID.String()))
 	}
 
 	if t.ConfigID != nil {
-		rule = append(rule, fmt.Sprintf("r.obj.config.id == %q", t.ConfigID.String()))
+		rule = append(rule, fmt.Sprintf("r.obj.Config.ID == %q", t.ConfigID.String()))
 	}
 
 	if t.CanaryID != nil {
-		rule = append(rule, fmt.Sprintf("r.obj.canary.id == %q", t.CanaryID.String()))
+		rule = append(rule, fmt.Sprintf("r.obj.Canary.ID == %q", t.CanaryID.String()))
 	}
 
 	if t.PlaybookID != nil {
-		rule = append(rule, fmt.Sprintf("r.obj.playbook.id == %q", t.PlaybookID.String()))
+		rule = append(rule, fmt.Sprintf("r.obj.Playbook.ID == %q", t.PlaybookID.String()))
 	}
 
 	if len(t.Agents) > 0 || len(t.Tags) > 0 {

--- a/models/permission_test.go
+++ b/models/permission_test.go
@@ -19,7 +19,7 @@ func TestPermission_Condition(t *testing.T) {
 			perm: Permission{
 				PlaybookID: lo.ToPtr(uuid.MustParse("33333333-3333-3333-3333-333333333333")),
 			},
-			expected: `r.obj.playbook.id == "33333333-3333-3333-3333-333333333333"`,
+			expected: `r.obj.Playbook.ID == "33333333-3333-3333-3333-333333333333"`,
 		},
 		{
 			name: "Multiple fields II",
@@ -27,7 +27,7 @@ func TestPermission_Condition(t *testing.T) {
 				ConfigID:   lo.ToPtr(uuid.MustParse("88888888-8888-8888-8888-888888888888")),
 				PlaybookID: lo.ToPtr(uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
 			},
-			expected: `r.obj.config.id == "88888888-8888-8888-8888-888888888888" && r.obj.playbook.id == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`,
+			expected: `r.obj.Config.ID == "88888888-8888-8888-8888-888888888888" && r.obj.Playbook.ID == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"`,
 		},
 		{
 			name:     "No fields set",

--- a/models/playbooks.go
+++ b/models/playbooks.go
@@ -422,24 +422,8 @@ func (p *PlaybookRun) String(db *gorm.DB) string {
 	return s
 }
 
-type RBACAttribute struct {
-	Playbook  Playbook   `json:"playbook"`
-	Component Component  `json:"component"`
-	Config    ConfigItem `json:"config"`
-	Check     Check      `json:"check"`
-}
-
-func (r RBACAttribute) AsMap() map[string]any {
-	return map[string]any{
-		"component": r.Component.AsMap(),
-		"config":    r.Config.AsMap(),
-		"check":     r.Check.AsMap(),
-		"playbook":  r.Playbook.AsMap(),
-	}
-}
-
-func (run *PlaybookRun) GetRBACAttributes(db *gorm.DB) (*RBACAttribute, error) {
-	var output RBACAttribute
+func (run *PlaybookRun) GetABACAttributes(db *gorm.DB) (*ABACAttribute, error) {
+	var output ABACAttribute
 
 	var playbook Playbook
 	if err := db.First(&playbook, run.PlaybookID).Error; err != nil {


### PR DESCRIPTION
We reference the fields directly (i.e. Go field names) - not the json field names.
This avoids all `.AsMap()` and `.ToMap()` serializations.

Also, explains the `Unable to access unexported field 'playbook'` error in https://github.com/flanksource/duty/pull/1275. 