### PR TITLE
fix: allow setting up env from multiple connections at once. Example: needing to setup EKS kubeconfig & the aws connection.

### DIFF
--- a/connection/environment.go
+++ b/connection/environment.go
@@ -116,8 +116,6 @@ func SetupConnection(ctx context.Context, connections ExecConnections, cmd *osEx
 		}
 	}
 
-	cmd.Env = os.Environ()
-
 	if connections.Kubernetes != nil {
 		if lo.FromPtr(connections.FromConfigItem) == "" {
 			if err := connections.Kubernetes.Populate(ctx); err != nil {

--- a/connection/git.go
+++ b/connection/git.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/utils"
 	"github.com/flanksource/duty/context"
 	"github.com/samber/lo"
 
@@ -166,6 +167,22 @@ type GitConnection struct {
 	// Destination is the full path to where the contents of the URL should be downloaded to.
 	// If left empty, the sha256 hash of the URL will be used as the dir name.
 	Destination *string `yaml:"destination,omitempty" json:"destination,omitempty"`
+}
+
+func (git GitConnection) GetURL() types.EnvVar {
+	return types.EnvVar{ValueStatic: git.URL}
+}
+
+func (git GitConnection) GetUsername() types.EnvVar {
+	return utils.Deref(git.Username)
+}
+
+func (git GitConnection) GetPassword() types.EnvVar {
+	return utils.Deref(git.Password)
+}
+
+func (git GitConnection) GetCertificate() types.EnvVar {
+	return utils.Deref(git.Certificate)
 }
 
 func (c *GitConnection) HydrateConnection(ctx context.Context) error {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -199,7 +199,7 @@ func runCmd(ctx context.Context, cmd *commandContext) (*ExecDetails, error) {
 			"stdout", result.Stdout,
 			"extra", result.Extra,
 			"exit-code", result.ExitCode,
-		).Code(fmt.Sprintf("exited with %d", result.ExitCode)).Errorf(result.Error.Error())
+		).Code(fmt.Sprintf("exited with %d", result.ExitCode)).Errorf("%v", result.Error.Error())
 	}
 
 	return &result, nil


### PR DESCRIPTION
fix: Support kubeconfig path

related: https://github.com/flanksource/mission-control-registry/issues/372