### PR TITLE
feat: unkeyed search on tags & properties

### DIFF
--- a/query/grammar/query.go
+++ b/query/grammar/query.go
@@ -41,11 +41,12 @@ func (op QueryOperator) ToSelectionOperator() selection.Operator {
 }
 
 type QueryField struct {
-	Field  string        `json:"field,omitempty"`
-	Value  interface{}   `json:"value,omitempty"`
-	Op     QueryOperator `json:"op,omitempty"`
-	Not    bool          `json:"not,omitempty"`
-	Fields []*QueryField `json:"fields,omitempty"`
+	Field     string        `json:"field,omitempty"`
+	FieldType FieldType     `json:"fieldType,omitempty"`
+	Value     interface{}   `json:"value,omitempty"`
+	Op        QueryOperator `json:"op,omitempty"`
+	Not       bool          `json:"not,omitempty"`
+	Fields    []*QueryField `json:"fields,omitempty"`
 }
 
 func (q QueryField) ToClauses() ([]clause.Expression, error) {
@@ -59,9 +60,9 @@ func (q QueryField) ToClauses() ([]clause.Expression, error) {
 	var clauses []clause.Expression
 	switch q.Op {
 	case Eq:
-		clauses = append(clauses, filters.ToExpression(q.Field)...)
+		clauses = append(clauses, filters.ToExpression(q.Field, q.FieldType)...)
 	case Neq:
-		clauses = append(clauses, clause.Not(filters.ToExpression(q.Field)...))
+		clauses = append(clauses, clause.Not(filters.ToExpression(q.Field, q.FieldType)...))
 	case Lt:
 		clauses = append(clauses, clause.Lt{Column: q.Field, Value: q.Value})
 	case Gt:

--- a/schema/apply.go
+++ b/schema/apply.go
@@ -45,7 +45,11 @@ func skipDropTables(changes []schema.Change) []schema.Change {
 
 func Apply(ctx context.Context, connection string) error {
 	log := logger.GetLogger("migrate")
-	from, err := dbReader(ctx, connection, []string{})
+
+	// https://atlasgo.io/versioned/diff#exclude-objects
+	exclude := []string{"config_items.properties_values", "components.properties_values"}
+
+	from, err := dbReader(ctx, connection, exclude)
 	if err != nil {
 		return fmt.Errorf("failed to open connection: %w", err)
 	}

--- a/schema/components.hcl
+++ b/schema/components.hcl
@@ -280,20 +280,6 @@ table "components" {
     null = true
     type = jsonb
   }
-  column "properties_values" {
-    null    = true
-    type    = jsonb
-    comment = "derived from the properties column to improve search performance for unkeyed property values"
-    as {
-      expr = <<-EOF
-      CASE 
-        WHEN properties IS NULL THEN NULL 
-        ELSE jsonb_path_query_array(properties, '$[*].text'::jsonpath) || jsonb_path_query_array(properties, '$[*].value'::jsonpath) 
-      END
-      EOF
-      type = STORED
-    }
-  }
   column "path" {
     null = true
     type = text
@@ -376,10 +362,6 @@ table "components" {
   }
   index "idx_components_properties" {
     columns = [column.properties]
-    type    = GIN
-  }
-  index "idx_components_properties_values" {
-    columns = [column.properties_values]
     type    = GIN
   }
   index "components_topology_id_type_name_parent_id_key" {

--- a/schema/components.hcl
+++ b/schema/components.hcl
@@ -280,6 +280,20 @@ table "components" {
     null = true
     type = jsonb
   }
+  column "properties_values" {
+    null    = true
+    type    = jsonb
+    comment = "derived from the properties column to improve search performance for unkeyed property values"
+    as {
+      expr = <<-EOF
+      CASE 
+        WHEN properties IS NULL THEN NULL 
+        ELSE jsonb_path_query_array(properties, '$[*].text'::jsonpath) || jsonb_path_query_array(properties, '$[*].value'::jsonpath) 
+      END
+      EOF
+      type = STORED
+    }
+  }
   column "path" {
     null = true
     type = text
@@ -362,6 +376,10 @@ table "components" {
   }
   index "idx_components_properties" {
     columns = [column.properties]
+    type    = GIN
+  }
+  index "idx_components_properties_values" {
+    columns = [column.properties_values]
     type    = GIN
   }
   index "components_topology_id_type_name_parent_id_key" {

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -320,20 +320,6 @@ table "config_items" {
       type = STORED
     }
   }
-  column "properties_values" {
-    null    = true
-    type    = jsonb
-    comment = "derived from the properties column to improve search performance for unkeyed property values"
-    as {
-      expr = <<-EOF
-      CASE 
-        WHEN properties IS NULL THEN NULL 
-        ELSE jsonb_path_query_array(properties, '$[*].text'::jsonpath) || jsonb_path_query_array(properties, '$[*].value'::jsonpath) 
-      END
-      EOF
-      type = STORED
-    }
-  }
   column "properties" {
     null = true
     type = jsonb
@@ -428,10 +414,6 @@ table "config_items" {
   }
   index "idx_config_items_tags_values" {
     columns = [column.tags_values]
-    type    = GIN
-  }
-  index "idx_config_items_properties_values" {
-    columns = [column.properties_values]
     type    = GIN
   }
   index "idx_config_items_name" {

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -308,6 +308,18 @@ table "config_items" {
     type    = jsonb
     comment = "contains a list of tags"
   }
+  column "tags_values" {
+    null    = true
+    type    = jsonb
+    comment = "a generated from tags column to get a better search on tag values"
+    as {
+      # without the ::jsonpath type casting
+      # we get this error from Atlas: failed to compute diff: failed to diff realms: 
+      # changing the generation expression for a column "tags_values" is not supported
+      expr = "(jsonb_path_query_array(tags, '$[*].*'::jsonpath))"
+      type = STORED
+    }
+  }
   column "properties" {
     null = true
     type = jsonb
@@ -398,6 +410,10 @@ table "config_items" {
   }
   index "idx_config_items_tags" {
     columns = [column.tags]
+    type    = GIN
+  }
+  index "idx_config_items_tags_values" {
+    columns = [column.tags_values]
     type    = GIN
   }
   index "idx_config_items_name" {

--- a/tests/fixtures/dummy/config.go
+++ b/tests/fixtures/dummy/config.go
@@ -175,6 +175,7 @@ var KubernetesNodeB = models.ConfigItem{
 	Properties: &types.Properties{
 		{Name: "memory", Value: lo.ToPtr(int64(32))},
 		{Name: "region", Text: "us-west-2"},
+		{Name: "os", Text: "linux"},
 	},
 	CostTotal30d: 1.5,
 }

--- a/tests/fixtures/dummy/config.go
+++ b/tests/fixtures/dummy/config.go
@@ -137,6 +137,7 @@ var KubernetesNodeA = models.ConfigItem{
 	Tags: types.JSONStringMap{
 		"cluster": "aws",
 		"account": "flanksource",
+		"region":  "us-east-1",
 	},
 	Health: lo.ToPtr(models.HealthHealthy),
 	Labels: lo.ToPtr(types.JSONStringMap{

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -577,6 +577,22 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 			resource: "config",
 		},
 		{
+			description: "tags prefix search",
+			query:       "tags=us-*",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeA.ID,
+			},
+			resource: "config",
+		},
+		{
+			description: "tags suffix search",
+			query:       "tags=*east-1",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeA.ID,
+			},
+			resource: "config",
+		},
+		{
 			description: "labels value search",
 			query:       "labels=managed",
 			expectedIDs: []uuid.UUID{
@@ -598,7 +614,7 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 
 	ginkgo.Describe("peg search", func() {
 		for _, tt := range testData {
-			// if tt.description != "tags value search negate" {
+			// if tt.description != "tags suffix search" {
 			// 	continue
 			// }
 

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -600,6 +600,30 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 			},
 			resource: "config",
 		},
+		{
+			description: "properties unkeyed value search",
+			query:       "properties=linux",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeB.ID,
+			},
+			resource: "config",
+		},
+		{
+			description: "properties unkeyed value search | prefix",
+			query:       "properties=us-west*",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeB.ID,
+			},
+			resource: "config",
+		},
+		{
+			description: "properties keyed value search",
+			query:       "properties.os=linux",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeB.ID,
+			},
+			resource: "config",
+		},
 	}
 
 	fmap := map[string]func(context.Context, int, ...types.ResourceSelector) ([]uuid.UUID, error){
@@ -614,7 +638,7 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 
 	ginkgo.Describe("peg search", func() {
 		for _, tt := range testData {
-			// if tt.description != "tags suffix search" {
+			// if tt.description != "properties keyed value search" {
 			// 	continue
 			// }
 

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -560,6 +560,30 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 			},
 			resource: "config",
 		},
+		{
+			description: "tags value search",
+			query:       "tags=us-east-1",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeA.ID,
+			},
+			resource: "config",
+		},
+		{
+			description: "tags value search negate",
+			query:       "type=Kubernetes::Node tags!=aws",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeAKSPool1.ID,
+			},
+			resource: "config",
+		},
+		{
+			description: "labels value search",
+			query:       "labels=managed",
+			expectedIDs: []uuid.UUID{
+				dummy.KubernetesNodeB.ID,
+			},
+			resource: "config",
+		},
 	}
 
 	fmap := map[string]func(context.Context, int, ...types.ResourceSelector) ([]uuid.UUID, error){
@@ -572,14 +596,20 @@ var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 		return lo.Map(uuids, func(item uuid.UUID, _ int) string { return item.String() })
 	}
 
-	for _, tt := range testData {
-		ginkgo.It(tt.description, func() {
-			f, ok := fmap[tt.resource]
-			Expect(ok).To(BeTrue())
-			ids, err := f(DefaultContext, -1, types.ResourceSelector{Search: tt.query})
-			Expect(err).To(BeNil())
-			// We convert to strings slice for readable output
-			Expect(uuidSliceToString(ids)).To(ConsistOf(uuidSliceToString(tt.expectedIDs)))
-		})
-	}
+	ginkgo.Describe("peg search", func() {
+		for _, tt := range testData {
+			// if tt.description != "tags value search negate" {
+			// 	continue
+			// }
+
+			ginkgo.It(tt.description, func() {
+				f, ok := fmap[tt.resource]
+				Expect(ok).To(BeTrue())
+				ids, err := f(DefaultContext, -1, types.ResourceSelector{Search: tt.query})
+				Expect(err).To(BeNil())
+				// We convert to strings slice for readable output
+				Expect(uuidSliceToString(ids)).To(ConsistOf(uuidSliceToString(tt.expectedIDs)))
+			})
+		}
+	})
 })

--- a/views/002_seed.sql
+++ b/views/002_seed.sql
@@ -24,3 +24,40 @@ BEGIN
             (5, 'Low', 'info', ARRAY['P4']);
    END IF;
 END $$;
+
+-- These columns are generated via a script instead of being defined through atlas schemas,
+-- because atlas fails to generate an accurate diff for them.
+-- it always detects a change in the expression.
+DO $$ 
+DECLARE 
+  tbl TEXT;
+  tables TEXT[] := ARRAY['components', 'config_items'];
+BEGIN
+  FOREACH tbl IN ARRAY tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 
+      FROM information_schema.columns 
+      WHERE table_name = tbl AND column_name = 'properties_values'
+    ) THEN
+      EXECUTE format('
+          ALTER TABLE %I 
+          ADD COLUMN properties_values JSONB 
+          GENERATED ALWAYS AS (
+              CASE 
+                  WHEN properties IS NULL THEN NULL 
+                  ELSE jsonb_path_query_array(properties, ''$[*].text''::jsonpath) || 
+                        jsonb_path_query_array(properties, ''$[*].value''::jsonpath) 
+              END
+          ) STORED;
+      ', tbl);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 
+      FROM pg_indexes 
+      WHERE tablename = tbl AND indexname = tbl || '_properties_values_gin_idx'
+    ) THEN
+        EXECUTE format('CREATE INDEX %I ON %I USING GIN (properties_values)', tbl || '_properties_values_gin_idx', tbl);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
resolves: https://github.com/flanksource/duty/issues/1305


```sql
incident_commander> EXPLAIN (ANALYZE, BUFFERS) SELECT name, type, tags
 FROM config_items
 WHERE  tags_values ?| ARRAY['immich']
+----------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                             |
|----------------------------------------------------------------------------------------------------------------------------------------|
| Bitmap Heap Scan on config_items  (cost=12.95..122.39 rows=31 width=101) (actual time=0.014..0.041 rows=31 loops=1)                    |
|   Recheck Cond: (tags_values ?| '{immich}'::text[])                                                                                    |
|   Heap Blocks: exact=28                                                                                                                |
|   Buffers: shared hit=32                                                                                                               |
|   ->  Bitmap Index Scan on idx_config_items_tags_values  (cost=0.00..12.94 rows=31 width=0) (actual time=0.010..0.010 rows=31 loops=1) |
|         Index Cond: (tags_values ?| '{immich}'::text[])                                                                                |
|         Buffers: shared hit=4                                                                                                          |
| Planning:                                                                                                                              |
|   Buffers: shared hit=134                                                                                                              |
| Planning Time: 0.169 ms                                                                                                                |
| Execution Time: 0.048 ms                                                                                                               |
+----------------------------------------------------------------------------------------------------------------------------------------+
```

vs

```sql
incident_commander> EXPLAIN (ANALYZE, BUFFERS) SELECT name, type, tags
 FROM config_items
 WHERE EXISTS (SELECT 1 FROM jsonb_each_text(tags) WHERE value = 'immich')
+-------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                              |
|-------------------------------------------------------------------------------------------------------------------------|
| Seq Scan on config_items  (cost=0.00..10967.96 rows=3868 width=101) (actual time=0.659..17.062 rows=31 loops=1)         |
|   Filter: (SubPlan 1)                                                                                                   |
|   Rows Removed by Filter: 7700                                                                                          |
|   Buffers: shared hit=1200 dirtied=16                                                                                   |
|   SubPlan 1                                                                                                             |
|     ->  Function Scan on jsonb_each_text  (cost=0.00..1.25 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=7731) |
|           Filter: (value = 'immich'::text)                                                                              |
|           Rows Removed by Filter: 2                                                                                     |
| Planning Time: 0.057 ms                                                                                                 |
| Execution Time: 17.154 ms                                                                                               |
```