### PR TITLE
fix: config changes for notification

### DIFF
--- a/views/021_notification.sql
+++ b/views/021_notification.sql
@@ -174,7 +174,7 @@ BEGIN
     -- Only config item notifications need to be inserted
     IF NEW.source_event LIKE 'config.%' AND ((TG_OP = 'INSERT') OR (TG_OP = 'UPDATE' AND OLD.status != NEW.status)) AND NEW.status != '' THEN
         INSERT INTO config_changes (config_id, change_type, source, details, external_change_id)
-        VALUES (NEW.resource_id, CONCAT('Notification', INITCAP(NEW.status)), 'notification', NEW.payload, CONCAT(NEW.id, '-', NOW()));
+        VALUES (NEW.resource_id, CONCAT('Notification', INITCAP(NEW.status)), 'notification', NEW.payload, CONCAT(NEW.id, '-', NEW.status, '-', CURRENT_TIMESTAMP));
     END IF;
 
     RETURN NEW;


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/1838

got a lot of `config_changes_config_id_external_change_id_key` violation errors.

I assume it's due to multiple changes being inserted in a single transaction.

```
12:27:08.21 DBG (job. process pending notifications) [notification.send] config.unhealthy
12:27:08.216 ERR (db) ERROR >=[1ms] [rows:0] ERROR: duplicate key value violates unique constraint "config_changes_config_id_external_change_id_key" (SQLSTATE 23505) UPDATE "notification_send_history" SET "status"=$1$ WHERE id IN ($2$)
12:27:08.217 ERR (db) ERROR >=[1ms] [rows:0] ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02) UPDATE "notification_send_history" SET "error"='failed to save notification status as sent: %!w(<nil>)',"retries"=retries + 1,"status"
=CASE WHEN retries >= 3 THEN 'error' ELSE 'pending' END WHERE id = '0194f3b3-ac0e-604c-2ad5-76dc9fdf7403'
12:27:08.219 ERR (job. process pending notifications) ProcessPendingNotifications failed to send pending notification: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
failed to save notification status as sent: %!w(<nil>)
12:27:10.225 DBG (job. process pending notifications) [notification.send] config.unhealthy
12:27:10.229 ERR (db) ERROR >=[0ms] [rows:0] ERROR: duplicate key value violates unique constraint "config_changes_config_id_external_change_id_key" (SQLSTATE 23505) UPDATE "notification_send_history" SET "status"=$1$ WHERE id IN ($2$)
12:27:10.23 ERR (db) ERROR >=[0ms] [rows:0] ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02) UPDATE "notification_send_history" SET "error"='failed to save notification status as sent: %!w(<nil>)',"retries"=retries + 1,"status"=
CASE WHEN retries >= 3 THEN 'error' ELSE 'pending' END WHERE id = '0194f3b3-ac0e-604c-2ad5-76dc9fdf7403'
12:27:10.231 ERR (job. process pending notifications) ProcessPendingNotifications failed to send pending notification: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
failed to save notification status as sent: %!w(<nil>)
12:27:12.237 DBG (job. process pending notifications) [notification.send] config.unhealthy
12:27:12.243 ERR (db) ERROR >=[1ms] [rows:0] ERROR: duplicate key value violates unique constraint "config_changes_config_id_external_change_id_key" (SQLSTATE 23505) UPDATE "notification_send_history" SET "status"=$1$ WHERE id IN ($2$)
12:27:12.244 ERR (db) ERROR >=[1ms] [rows:0] ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02) UPDATE "notification_send_history" SET "error"='failed to save notification status as sent: %!w(<nil>)',"retries"=retries + 1,"status"
=CASE WHEN retries >= 3 THEN 'error' ELSE 'pending' END WHERE id = '0194f3b3-ac0e-604c-2ad5-76dc9fdf7403'
12:27:12.245 ERR (job. process pending notifications) ProcessPendingNotifications failed to send pending notification: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
```