### PR TITLE
fix: avoid passing empty slices to stat.Quantile

### DIFF
--- a/query/check_details.go
+++ b/query/check_details.go
@@ -195,6 +195,11 @@ ORDER BY time
 		results = append(results, datapoint)
 	}
 
+	// stat.Quantile panics on empty lists so we return early
+	if len(results) == 0 {
+		return nil, uptime, types.Latency{}, nil
+	}
+
 	// Sorting is required before calculating latencies else Quantile panics
 	slices.Sort(latencies)
 	latency := types.Latency{


### PR DESCRIPTION
Fixes https://github.com/flanksource/canary-checker/issues/2510