### PR TITLE
fix: dropping events

### DIFF
--- a/postq/event.go
+++ b/postq/event.go
@@ -31,8 +31,7 @@ func fetchEvents(ctx context.Context, tx *gorm.DB, watchEvents []string, batchSi
 	}
 
 	const selectEventsQuery = `
-		DELETE FROM event_queue
-		WHERE id IN (
+		WITH to_delete AS (
 			SELECT id FROM event_queue
 			WHERE
 				(delay IS NULL OR created_at + (delay * INTERVAL '1 second' / 1000000000)  <= NOW()) AND
@@ -43,6 +42,8 @@ func fetchEvents(ctx context.Context, tx *gorm.DB, watchEvents []string, batchSi
 			FOR UPDATE SKIP LOCKED
 			LIMIT @BatchSize
 		)
+		DELETE FROM event_queue
+		WHERE id IN (SELECT id FROM to_delete)
 		RETURNING *
 	`
 

--- a/tests/event_queue_test.go
+++ b/tests/event_queue_test.go
@@ -1,18 +1,53 @@
 package tests
 
 import (
+	"fmt"
+
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/postq"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = ginkgo.Describe("Event queue views", func() {
+var _ = ginkgo.Describe("Event queue", func() {
 	ginkgo.It("should query event queue views", func() {
 		var summaries []models.EventQueueSummary
 		err := DefaultContext.DB().Find(&summaries).Error
 		Expect(err).ToNot(HaveOccurred())
 
 		logger.Infof("eventQueueSummary (%d)", len(summaries))
+	})
+
+	ginkgo.It("should process event queue one at a time", func() {
+		const iterations = 10
+		const eventName = "test.one-at-a-time"
+		var handlerInvocationCount int // number of times the event handler is called
+
+		syncConsumer := postq.SyncEventConsumer{
+			WatchEvents: []string{eventName},
+			Consumers: []postq.SyncEventHandlerFunc{
+				func(ctx context.Context, e models.Event) error {
+					handlerInvocationCount++
+					return nil
+				},
+			},
+		}
+
+		consumer, err := syncConsumer.EventConsumer()
+		Expect(err).ToNot(HaveOccurred())
+
+		for i := range iterations {
+			DefaultContext.DB().Create(&models.Event{
+				Name: eventName,
+				Properties: map[string]string{
+					"id": fmt.Sprintf("%d", i),
+				},
+			})
+		}
+
+		consumer.ConsumeUntilEmpty(DefaultContext)
+		Expect(handlerInvocationCount).To(Equal(iterations))
 	})
 })


### PR DESCRIPTION
Sometimes the planner would use `Nested Loop Semi Join` which would cause all the events to be deleted even with a LIMIT of 1. The sync consumer is expecting just one event so it uses the first from the list. All the other events get deleted but only one gets processed.

This isn't reproducible consistently.

## Deletes 1

```
EXPLAIN (ANALYZE, BUFFERS) DELETE FROM event_queue
         WHERE id IN (
             SELECT id FROM event_queue
             ORDER BY priority DESC, created_at ASC
             FOR UPDATE SKIP LOCKED
             LIMIT 1
         )
         RETURNING *
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                           |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Delete on event_queue  (cost=9.69..17.75 rows=1 width=46) (actual time=0.137..0.139 rows=1 loops=1)                                                                  |
|   Buffers: shared hit=7                                                                                                                                              |
|   ->  Nested Loop  (cost=9.69..17.75 rows=1 width=46) (actual time=0.126..0.128 rows=1 loops=1)                                                                      |
|         Buffers: shared hit=5                                                                                                                                        |
|         ->  HashAggregate  (cost=9.54..9.55 rows=1 width=56) (actual time=0.111..0.112 rows=1 loops=1)                                                               |
|               Group Key: "ANY_subquery".id                                                                                                                           |
|               Batches: 1  Memory Usage: 24kB                                                                                                                         |
|               Buffers: shared hit=3                                                                                                                                  |
|               ->  Subquery Scan on "ANY_subquery"  (cost=9.51..9.54 rows=1 width=56) (actual time=0.106..0.107 rows=1 loops=1)                                       |
|                     Buffers: shared hit=3                                                                                                                            |
|                     ->  Limit  (cost=9.51..9.53 rows=1 width=34) (actual time=0.100..0.101 rows=1 loops=1)                                                           |
|                           Buffers: shared hit=3                                                                                                                      |
|                           ->  LockRows  (cost=9.51..9.54 rows=2 width=34) (actual time=0.099..0.099 rows=1 loops=1)                                                  |
|                                 Buffers: shared hit=3                                                                                                                |
|                                 ->  Sort  (cost=9.51..9.52 rows=2 width=34) (actual time=0.087..0.087 rows=1 loops=1)                                                |
|                                       Sort Key: event_queue_1.priority DESC, event_queue_1.created_at                                                                |
|                                       Sort Method: quicksort  Memory: 25kB                                                                                           |
|                                       Buffers: shared hit=2                                                                                                          |
|                                       ->  Bitmap Heap Scan on event_queue event_queue_1  (cost=4.16..9.50 rows=2 width=34) (actual time=0.046..0.048 rows=9 loops=1) |
|                                             Recheck Cond: (name = 'test.one-at-a-time'::text)                                                                        |
|                                             Heap Blocks: exact=1                                                                                                     |
|                                             Buffers: shared hit=2                                                                                                    |
|                                             ->  Bitmap Index Scan on event_queue_pop  (cost=0.00..4.16 rows=2 width=0) (actual time=0.034..0.034 rows=10 loops=1)    |
|                                                   Index Cond: (name = 'test.one-at-a-time'::text)                                                                    |
|                                                   Buffers: shared hit=1                                                                                              |
|         ->  Index Scan using event_queue_pkey on event_queue  (cost=0.15..8.17 rows=1 width=22) (actual time=0.013..0.013 rows=1 loops=1)                            |
|               Index Cond: (id = "ANY_subquery".id)                                                                                                                   |
|               Buffers: shared hit=2                                                                                                                                  |
| Planning Time: 0.411 ms                                                                                                                                              |
| Execution Time: 0.231 ms                                                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## Deletes all

```
 EXPLAIN (ANALYZE, BUFFERS) DELETE FROM event_queue
         WHERE id IN (
             SELECT id FROM event_queue
             ORDER BY priority DESC, created_at ASC
             FOR UPDATE SKIP LOCKED
             LIMIT 1
         )
         RETURNING *
+--------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                             |
|--------------------------------------------------------------------------------------------------------------------------------------------------------|
| Delete on event_queue  (cost=1.01..2.05 rows=1 width=46) (actual time=0.098..0.111 rows=3 loops=1)                                                     |
|   Buffers: shared hit=14                                                                                                                               |
|   ->  Nested Loop Semi Join  (cost=1.01..2.05 rows=1 width=46) (actual time=0.088..0.096 rows=3 loops=1)                                               |
|         Join Filter: (event_queue.id = "ANY_subquery".id)                                                                                              |
|         Buffers: shared hit=8                                                                                                                          |
|         ->  Seq Scan on event_queue  (cost=0.00..1.00 rows=1 width=22) (actual time=0.022..0.024 rows=3 loops=1)                                       |
|               Buffers: shared hit=1                                                                                                                    |
|         ->  Subquery Scan on "ANY_subquery"  (cost=1.01..1.03 rows=1 width=56) (actual time=0.022..0.022 rows=1 loops=3)                               |
|               Buffers: shared hit=7                                                                                                                    |
|               ->  Limit  (cost=1.01..1.02 rows=1 width=34) (actual time=0.019..0.019 rows=1 loops=3)                                                   |
|                     Buffers: shared hit=7                                                                                                              |
|                     ->  LockRows  (cost=1.01..1.02 rows=1 width=34) (actual time=0.019..0.019 rows=1 loops=3)                                          |
|                           Buffers: shared hit=7                                                                                                        |
|                           ->  Sort  (cost=1.01..1.01 rows=1 width=34) (actual time=0.007..0.007 rows=2 loops=3)                                        |
|                                 Sort Key: event_queue_1.priority DESC, event_queue_1.created_at                                                        |
|                                 Sort Method: quicksort  Memory: 25kB                                                                                   |
|                                 Buffers: shared hit=1                                                                                                  |
|                                 ->  Seq Scan on event_queue event_queue_1  (cost=0.00..1.00 rows=1 width=34) (actual time=0.003..0.004 rows=3 loops=1) |
|                                       Buffers: shared hit=1                                                                                            |
| Planning Time: 0.359 ms                                                                                                                                |
| Execution Time: 0.173 ms                                                                                                                               |
+--------------------------------------------------------------------------------------------------------------------------------------------------------+
```