### PR TITLE
panic when more events, than the requested amount, is fetched

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	gonum.org/v1/gonum v0.15.1
 	google.golang.org/api v0.198.0
 	google.golang.org/grpc v1.66.2
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.12
@@ -292,6 +291,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect
 	gorm.io/driver/sqlserver v1.5.3 // indirect
 	gorm.io/plugin/dbresolver v1.5.3 // indirect

--- a/postq/event.go
+++ b/postq/event.go
@@ -85,5 +85,10 @@ func fetchEvents(ctx context.Context, tx *gorm.DB, watchEvents []string, batchSi
 	if len(events) > 0 {
 		ctx.Tracef("queue=%s fetched=%d", strings.Join(watchEvents, ","), len(events))
 	}
+
+	if len(events) > batchSize {
+		ctx.Errorf("fetched more events (%d) than the requested batch size (%d)", len(events), batchSize)
+	}
+
 	return events, nil
 }


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/1987

Maybe, events are being dropped. This should never happen.