### PR TITLE
fix: least privilege permission

### DIFF
--- a/rbac/custom_functions.go
+++ b/rbac/custom_functions.go
@@ -78,10 +78,14 @@ func matchResourceSelectorPair(pair resourcePair) bool {
 		if len(pair.selectors) == 0 {
 			// An attribute was provided but there's no selector to match it against
 			//
-			// Essentially, what's happening here is that the permission was not restrictive enough.
-			// The selector in the permission doesn't care about this attribute.
-			// So it's authorized.
-			return true
+			// Essentially, what's happening here is that the permission is not specific enough.
+			//
+			// Example:
+			// Request: (playbook:run, subject:john, object:playbook.name='foo')
+			// Should fail when a playbook and config is passed (because the permission has not specified the config)
+			//
+			// The request must have been: (playbook:run, subject:john, object:playbook.name='foo'&config:bar)
+			return false
 		}
 
 		// Must match one of the selectors

--- a/rbac/custom_functions_test.go
+++ b/rbac/custom_functions_test.go
@@ -145,7 +145,7 @@ func Test_matchResourceSelector(t *testing.T) {
 		},
 		{
 			name: "2 attributes, 1 selector, match",
-			want: true,
+			want: false,
 			args: args{
 				attr: models.ABACAttribute{
 					Connection: models.Connection{


### PR DESCRIPTION
we need this to enforce permissions.

Example: we need to check if a person has `playbook:read` on a playbook=foo and config=bar

```go
casbin.Check(`john`, `playbook:run`, attribute{playbook: foo, config: bar})
```

If there's a permission like this

```yaml
subject: john
action: playbook:run
objects:
  playbook: foo
```

we have 2 attributes (passed on the request) but only a single object (in the policy) that addresses only one attribute (the playbook).

This single permission implicitly provides `playbook:run` to john on config=bar or any config.

Alternatively, the following permission would implicitly allow plabook:run on any playbook for all configs in namespace=default

```yaml
subject: john
action: playbook:run
objects:
  configs: namespace=default
```

---

This PR enforces the permissions to be explicit. 
So the permission would have to be

```yaml
subject: john
action: playbook:run
objects:
  playbook: foo
  configs: *
```

