### PR TITLE
fix: dedup inhibited

### DIFF
--- a/views/021_notification.sql
+++ b/views/021_notification.sql
@@ -68,6 +68,7 @@ BEGIN
     AND resource_id = p_resource_id
     AND status = p_status
     AND created_at > NOW() - p_window
+    AND (p_status != 'inhibited' OR parent_id = p_parent_id)
   ORDER BY
     created_at DESC
   LIMIT 1;


### PR DESCRIPTION
With two inhibition rules like this, a pod could be inhibited by different resources

```
PVC 
-> Pod

Node
-> Pod
```

When pod gets inhibited by PVC, we want to dedup to the send history that was inhibited by the PVC.