### PR TITLE
feat: dedup skipped notifications

### DIFF
--- a/models/notifications.go
+++ b/models/notifications.go
@@ -123,7 +123,7 @@ type NotificationSendHistory struct {
 
 	// Notifications that were silenced or blocked by repeat intervals
 	// use this counter.
-	Count int `json:"count"`
+	Count int `json:"count" gorm:"default:1"`
 
 	// Notifications that were silenced or blocked by repeat intervals
 	// use this as the first observed timestamp.


### PR DESCRIPTION
Unlike other deduplication like with status = repeated, silenced, deduplication of skipped notifications are different.


For repeated/silenced/inhibited notifications:
- We either create a new record, or
- Update the count of an existing record with the same status

For skipped notifications:
- A notification record already exists with status "pending" or "evaluating-waitfor"
- When deduplicating, we need to:
  1. Increment the count of the existing skipped record, AND
  2. Delete the corresponding "pending" or "evaluating-waitfor" send history