### PR TITLE
fix: inject kube env vars for exec action with config item

### DIFF
--- a/connection/environment.go
+++ b/connection/environment.go
@@ -183,7 +183,8 @@ func SetupConnection(ctx context.Context, connections ExecConnections, cmd *osEx
 				}
 			}
 
-			if !kubeconfigFound && connections.ServiceAccount {
+			// Use local kubernetes if no external kubeconfig is found
+			if !kubeconfigFound {
 				injectKubernetesServiceAccount(ctx, cmd)
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control/issues/2061