### PR TITLE
fix: failing test "FindCatalogChanges"

### DIFF
--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -235,6 +235,7 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 		ginkgo.It("Without catalog id", func() {
 			response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
 				ConfigType: "Kubernetes::Pod,Kubernetes::ReplicaSet",
+				ChangeType: "!NotificationSent",
 			})
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
Another notification test would sometimes run before this test and create new `config_changes`.