### PR TITLE
fix: migration test for postgres v14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,22 +60,33 @@ jobs:
           - { tag: "15", sha: "sha256:f57a3bdbf044f0b213fdc99f35a0d21c401608bf41f063176ec00c51df9655f7" }
           - { tag: "16", sha: "sha256:47053cd4ee3f096afc744e53e3280de7b29b3670d2f2196c2acc0c6470923c99" }
     env:
-      migrate_command: make -B tidy hack/migrate/go.mod && cd hack/migrate && go run main.go --db-url 'postgres://postgres:postgres@localhost:5432/test?sslmode=disable'
+      migrate_command: >
+        make -B tidy hack/migrate/go.mod && 
+        cd hack/migrate && 
+        go build main.go && ./main --db-url 'postgres://postgres:postgres@localhost:5432/test?sslmode=disable'
     steps:
       - name: Install Go
         uses: buildjet/setup-go@v5
         with:
           go-version: 1.24.x
+      
       - name: Check out main branch
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           ref: main
+      
       - name: Apply base migrations
         run: ${{ env.migrate_command }}
+        env:
+          DUTY_DB_DISABLE_RLS: ${{ matrix.postgres-version.tag == '14' && 'true' || 'false' }}
+      
       - name: Check out current branch
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      
       - name: Apply new migrations
         run: ${{ env.migrate_command }}
+        env:
+          DUTY_DB_DISABLE_RLS: ${{ matrix.postgres-version.tag == '14' && 'true' || 'false' }}
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version.tag }}@${{ matrix.postgres-version.sha }}

--- a/hack/migrate/main.go
+++ b/hack/migrate/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/api"
@@ -8,24 +10,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	disableRLS = os.Getenv("DUTY_DB_DISABLE_RLS") == "true"
+	connection string
+)
+
 var migrate = &cobra.Command{
 	Use: "migrate",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := duty.Migrate(api.Config{
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return duty.Migrate(api.Config{
 			ConnectionString: connection,
-			EnableRLS:        true,
+			EnableRLS:        !disableRLS,
 			Postgrest:        api.DefaultConfig.Postgrest,
-		}); err != nil {
-			logger.Fatalf(err.Error())
-		}
+		})
 	},
 }
-
-var connection string
 
 func main() {
 	migrate.Flags().StringVar(&connection, "db-url", "", "Database URI: scheme://user:pass@host:port/database")
 	if err := migrate.Execute(); err != nil {
-		logger.Fatalf("failed to run migration: %v", err)
+		logger.Errorf("failed to run migration: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
`migrate` would never return exit code 1 so the CI would always pass even if the migration failed.

![image](https://github.com/user-attachments/assets/59b65ba3-34ad-44e4-841d-a41c1525587f)
