### PR TITLE
fix: json marshalling/unmarshalling of config items in matchQuery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 ## Tool Binaries
 LOCALBIN ?= $(shell pwd)/.bin
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GOLANGCI_LINT_VERSION ?= v2.1.6
 
 .PHONY: ginkgo
@@ -35,10 +37,6 @@ fmt:
 lint: golangci-lint
 	$(GOLANGCI_LINT) run ./...
 	go vet ./...
-
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
-LOCALBIN ?= $(shell pwd)/.bin
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,6 @@ require (
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.12
 	gorm.io/plugin/prometheus v0.1.0
-	gotest.tools/v3 v3.5.1
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1

--- a/query/template.go
+++ b/query/template.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 
 	"github.com/flanksource/duty/context"
-	"github.com/flanksource/duty/models"
 	dutyTypes "github.com/flanksource/duty/types"
 )
 
@@ -49,45 +47,7 @@ func MatchQueryCelFunc(ctx context.Context) cel.EnvOption {
 }
 
 func matchQuery(resourceSelectableRaw map[string]any, peg string) (bool, error) {
-	var resourceSelectable dutyTypes.ResourceSelectable = dutyTypes.ResourceSelectableMap(resourceSelectableRaw)
-
-	// NOTE: We check for fields in the map to determine what resource to unmarshal to.
-	if _, ok := resourceSelectableRaw["config_class"]; ok {
-		var config models.ConfigItem
-		if err := config.FromMap(resourceSelectableRaw); err != nil {
-			return false, fmt.Errorf("failed to unmarshal config item: %w", err)
-		}
-
-		resourceSelectable = config
-	} else if _, ok := resourceSelectableRaw["category"]; ok {
-		var playbook models.Playbook
-		if b, err := json.Marshal(resourceSelectableRaw); err != nil {
-			return false, err
-		} else if err := json.Unmarshal(b, &playbook); err != nil {
-			return false, err
-		}
-
-		resourceSelectable = &playbook
-	} else if _, ok := resourceSelectableRaw["topology_id"]; ok {
-		var component models.Component
-		if b, err := json.Marshal(resourceSelectableRaw); err != nil {
-			return false, err
-		} else if err := json.Unmarshal(b, &component); err != nil {
-			return false, err
-		}
-
-		resourceSelectable = component
-	} else if _, ok := resourceSelectableRaw["canary_id"]; ok {
-		var check models.Check
-		if b, err := json.Marshal(resourceSelectableRaw); err != nil {
-			return false, err
-		} else if err := json.Unmarshal(b, &check); err != nil {
-			return false, err
-		}
-
-		resourceSelectable = check
-	}
-
+	resourceSelectable := dutyTypes.ResourceSelectableMap(resourceSelectableRaw)
 	rs := dutyTypes.ResourceSelector{Search: peg}
 	return rs.Matches(resourceSelectable), nil
 }

--- a/query/template.go
+++ b/query/template.go
@@ -39,7 +39,7 @@ func MatchQueryCelFunc(ctx context.Context) cel.EnvOption {
 
 				match, err := matchQuery(resourceSelectableRaw, peg)
 				if err != nil {
-					return types.WrapErr(err)
+					return types.WrapErr(fmt.Errorf("matchQuery failed: %w", err))
 				}
 
 				return types.Bool(match)
@@ -52,13 +52,10 @@ func matchQuery(resourceSelectableRaw map[string]any, peg string) (bool, error) 
 	var resourceSelectable dutyTypes.ResourceSelectable = dutyTypes.ResourceSelectableMap(resourceSelectableRaw)
 
 	// NOTE: We check for fields in the map to determine what resource to unmarshal to.
-
 	if _, ok := resourceSelectableRaw["config_class"]; ok {
 		var config models.ConfigItem
-		if b, err := json.Marshal(resourceSelectableRaw); err != nil {
-			return false, err
-		} else if err := json.Unmarshal(b, &config); err != nil {
-			return false, err
+		if err := config.FromMap(resourceSelectableRaw); err != nil {
+			return false, fmt.Errorf("failed to unmarshal config item: %w", err)
 		}
 
 		resourceSelectable = config

--- a/query/template_test.go
+++ b/query/template_test.go
@@ -14,6 +14,10 @@ import (
 func TestMatchQuery(t *testing.T) {
 	config := models.ConfigItem{
 		Name: lo.ToPtr("aws-demo"),
+		Config: lo.ToPtr(`{
+			"aws_access_key_id": "1234567890",
+			"aws_secret_access_key": "1234567890"
+		}`),
 	}
 
 	playbook := models.Playbook{


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2144

**Bug Summary:**

  The issue was in query/template.go where the code needed to convert a map back to a ConfigItem struct. The problem occurred because the `Config` field in ConfigItem is stored as a JSON string (or pointer to string), but when represented in a map, the config data is actually a nested map object.

  The original code used manual JSON marshaling/unmarshaling to convert the map to ConfigItem, but this failed because it couldn't properly handle the type mismatch between the map's config field (map[string]any) and the struct's Config field (*string).

  **Solution:**

~~Added a new `FromMap` method on ConfigItem that specially handles the config field by detecting if it's a map and converting it to a JSON string~~

~~Alternatively, we can create a new ResourceSelectable map~~

Avoid marshalling/unmarshalling completely. Use `ResourceSelectableMap`