### PR TITLE
chore: remove dot imports from gomega

### DIFF
--- a/models/canary_test.go
+++ b/models/canary_test.go
@@ -2,21 +2,21 @@ package models
 
 import (
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Canary", func() {
+var _ = ginkgo.Describe("Canary", func() {
 	var (
 		id uuid.UUID
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		id = uuid.New()
 	})
 
-	Describe("AsMap", func() {
-		It("should remove single field", func() {
+	ginkgo.Describe("AsMap", func() {
+		ginkgo.It("should remove single field", func() {
 			canary := Canary{
 				ID:        id,
 				Namespace: "canary",
@@ -34,7 +34,7 @@ var _ = Describe("Canary", func() {
 			Expect(canary.AsMap()).To(Equal(expected))
 		})
 
-		It("should remove multiple fields", func() {
+		ginkgo.It("should remove multiple fields", func() {
 			canary := Canary{
 				ID:        uuid.New(),
 				Namespace: "canary",
@@ -49,7 +49,7 @@ var _ = Describe("Canary", func() {
 			Expect(canary.AsMap(removeFields...)).To(Equal(expected))
 		})
 
-		It("should remove no fields", func() {
+		ginkgo.It("should remove no fields", func() {
 			canary := Canary{
 				Namespace: "canary",
 				Name:      "dummy-canary",

--- a/models/config_test.go
+++ b/models/config_test.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -10,9 +10,9 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-var _ = Describe("AsMap", func() {
-	Context("ConfigItem", func() {
-		It("should remove specified fields", func() {
+var _ = ginkgo.Describe("AsMap", func() {
+	ginkgo.Context("ConfigItem", func() {
+		ginkgo.It("should remove specified fields", func() {
 			id := uuid.New()
 			config := ConfigItem{
 				ID:   id,
@@ -48,8 +48,8 @@ var _ = Describe("AsMap", func() {
 		})
 	})
 
-	Context("CatalogChange", func() {
-		It("should return details as a map", func() {
+	ginkgo.Context("CatalogChange", func() {
+		ginkgo.It("should return details as a map", func() {
 			change := CatalogChange{
 				ID:         uuid.New(),
 				ConfigID:   uuid.New(),

--- a/models/connections_test.go
+++ b/models/connections_test.go
@@ -3,12 +3,12 @@ package models
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Connection", func() {
-	Describe("AsGoGetterURL", func() {
+var _ = ginkgo.Describe("Connection", func() {
+	ginkgo.Describe("AsGoGetterURL", func() {
 		testCases := []struct {
 			name          string
 			connection    Connection
@@ -41,8 +41,8 @@ var _ = Describe("Connection", func() {
 
 		for _, tc := range testCases {
 			tc := tc // capture range variable
-			Context(tc.name, func() {
-				It("should return the correct URL and error", func() {
+			ginkgo.Context(tc.name, func() {
+				ginkgo.It("should return the correct URL and error", func() {
 					resultURL, err := tc.connection.AsGoGetterURL()
 					Expect(resultURL).To(Equal(tc.expectedURL))
 					if tc.expectedError == nil {
@@ -53,7 +53,7 @@ var _ = Describe("Connection", func() {
 		}
 	})
 
-	Describe("AsEnv", func() {
+	ginkgo.Describe("AsEnv", func() {
 		testCases := []struct {
 			name                string
 			connection          Connection
@@ -90,8 +90,8 @@ var _ = Describe("Connection", func() {
 
 		for _, tc := range testCases {
 			tc := tc // capture range variable
-			Context(tc.name, func() {
-				It("should return the correct environment variables and file content", func() {
+			ginkgo.Context(tc.name, func() {
+				ginkgo.It("should return the correct environment variables and file content", func() {
 					envPrep := tc.connection.AsEnv(context.Background())
 
 					for i, expected := range tc.expectedEnv {

--- a/models/suite_test.go
+++ b/models/suite_test.go
@@ -3,11 +3,11 @@ package models
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 func TestModels(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Models Suite")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Models Suite")
 }


### PR DESCRIPTION
`ginkgo` imports `Label` so we couldn't define our own Label type in `models` package.