### PR TITLE
fix: dataquery

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -280,7 +280,11 @@ func (k Context) WithConnectionString(connectionString string) Context {
 
 // ConnectionString returns the connection string for the database
 func (k Context) ConnectionString() string {
-	return k.Value("dbConnectionString").(string)
+	cn := k.Value("dbConnectionString")
+	if cn == nil {
+		return ""
+	}
+	return cn.(string)
 }
 
 // Returns a new named logger, the default db log level starts at INFO for DDL
@@ -591,6 +595,7 @@ func (k Context) HydrateConnection(connection *models.Connection) (*models.Conne
 func (k Context) Wrap(ctx gocontext.Context) Context {
 	return NewContext(ctx, commons.WithTracer(k.GetTracer()), commons.WithLogger(k.Logger)).
 		WithDB(k.DB(), k.Pool()).
+		WithConnectionString(k.ConnectionString()).
 		WithKubernetes(k.KubernetesConnection()).
 		WithNamespace(k.GetNamespace())
 }

--- a/dataquery/merge.go
+++ b/dataquery/merge.go
@@ -79,9 +79,7 @@ func mergeResultsets(ctx context.Context, mergeQuery string) ([]QueryResultRow, 
 
 		row := make(QueryResultRow)
 		for i, col := range columns {
-			if values[i] != nil {
-				row[col] = values[i]
-			}
+			row[col] = values[i]
 		}
 		results = append(results, row)
 	}

--- a/dataquery/merge_test.go
+++ b/dataquery/merge_test.go
@@ -15,30 +15,6 @@ func TestDataQuery(t *testing.T) {
 }
 
 var _ = Describe("MergeQueryResults", func() {
-	Describe("InferColumnTypes", func() {
-		It("should infer column types correctly", func() {
-			rows := []QueryResultRow{
-				{"id": 1, "name": "test1", "score": 95.5, "active": true},
-				{"id": 2, "name": "test2", "score": 87.2, "active": false},
-				{"id": 3, "name": "test3", "score": 92.1, "active": true},
-			}
-
-			columnTypes := InferColumnTypes(rows)
-
-			Expect(columnTypes).To(HaveLen(4))
-			Expect(columnTypes["id"]).To(Equal("INTEGER"))
-			Expect(columnTypes["name"]).To(Equal("TEXT"))
-			Expect(columnTypes["score"]).To(Equal("REAL"))
-			Expect(columnTypes["active"]).To(Equal("INTEGER"))
-		})
-
-		It("should handle empty rows", func() {
-			rows := []QueryResultRow{}
-			columnTypes := InferColumnTypes(rows)
-			Expect(columnTypes).To(HaveLen(0))
-		})
-	})
-
 	Describe("UNION operations", func() {
 		It("should merge result sets using UNION", func() {
 			resultSet1 := QueryResultSet{
@@ -102,7 +78,7 @@ var _ = Describe("MergeQueryResults", func() {
 			Expect(results).To(ConsistOf([]QueryResultRow{
 				{"users.id": int64(1), "users.name": "alice", "orders.user_id": int64(1), "orders.product": "laptop"},
 				{"users.id": int64(2), "users.name": "bob", "orders.user_id": int64(2), "orders.product": "mouse"},
-				{"users.id": int64(3), "users.name": "charlie"},
+				{"users.id": int64(3), "users.name": "charlie", "orders.user_id": nil, "orders.product": nil},
 			}))
 		})
 

--- a/dataquery/sqlite_test.go
+++ b/dataquery/sqlite_test.go
@@ -1,0 +1,108 @@
+package dataquery
+
+import (
+	"github.com/glebarez/sqlite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/flanksource/duty/context"
+)
+
+func testResultset(ctx context.Context, resultset QueryResultSet) {
+	Expect(resultset.CreateDBTable(ctx)).To(Succeed())
+	Expect(resultset.InsertToDB(ctx)).To(Succeed())
+
+	var results []map[string]any
+	Expect(ctx.DB().Table(resultset.Name).Find(&results).Error).To(Succeed())
+	Expect(results).To(HaveLen(len(resultset.Results)))
+}
+
+var _ = Describe("Insert complex values", func() {
+	var sqliteCtx = context.New()
+
+	BeforeEach(func() {
+		sqliteDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		Expect(err).ToNot(HaveOccurred())
+
+		sqliteCtx = sqliteCtx.WithDB(sqliteDB, nil)
+	})
+
+	It("should insert columns with string map values", func() {
+		resultSet := QueryResultSet{
+			Name: "table1",
+			Results: []QueryResultRow{
+				{"id": 1, "name": map[string]string{"first": "alice", "last": "smith"}},
+				{"id": 2, "name": map[string]string{"first": "bob", "last": "jones"}},
+			},
+		}
+
+		testResultset(sqliteCtx, resultSet)
+	})
+
+	It("should insert columns with map values", func() {
+		resultSet := QueryResultSet{
+			Name: "table1",
+			Results: []QueryResultRow{
+				{"id": 1, "address": map[string]any{"street": map[string]any{"name": "123 Main St", "number": 123}, "city": "Othertown", "state": "NY", "zip": "67890"}},
+				{"id": 2, "address": map[string]any{"street": map[string]any{"name": "456 Elm St", "number": 456}, "city": "Othertown", "state": "NY", "zip": "67890"}},
+			},
+		}
+
+		testResultset(sqliteCtx, resultSet)
+
+		var streetNames []string
+		Expect(sqliteCtx.DB().Table(resultSet.Name).Select(`address->"street"->>"name"`).Find(&streetNames).Error).To(Succeed())
+		Expect(streetNames).To(ConsistOf("123 Main St", "456 Elm St"))
+	})
+
+	It("should insert columns with struct values", func() {
+		type Street struct {
+			Name   string `json:"name"`
+			Number int    `json:"number"`
+		}
+
+		type Address struct {
+			Street Street `json:"street"`
+			City   string `json:"city"`
+		}
+
+		resultSet := QueryResultSet{
+			Name: "table1",
+			Results: []QueryResultRow{
+				{"id": 1, "address": Address{Street: Street{Name: "123 Main St", Number: 123}, City: "Othertown"}},
+				{"id": 2, "address": Address{Street: Street{Name: "456 Elm St", Number: 456}, City: "Othertown"}},
+			},
+		}
+
+		testResultset(sqliteCtx, resultSet)
+
+		var streetNames []string
+		Expect(sqliteCtx.DB().Table(resultSet.Name).Select(`address->"street"->>"name"`).Find(&streetNames).Error).To(Succeed())
+		Expect(streetNames).To(ConsistOf("123 Main St", "456 Elm St"))
+	})
+})
+
+var _ = Describe("InferColumnTypes", func() {
+	It("should infer column types correctly", func() {
+		rows := []QueryResultRow{
+			{"id": 1, "name": "test1", "score": 95.5, "active": true},
+			{"id": 2, "name": "test2", "score": 87.2, "active": false},
+			{"id": 3, "name": "test3", "score": 92.1, "active": true},
+		}
+
+		columnTypes := InferColumnTypes(rows)
+
+		Expect(columnTypes).To(HaveLen(4))
+		Expect(columnTypes["id"]).To(Equal("INTEGER"))
+		Expect(columnTypes["name"]).To(Equal("TEXT"))
+		Expect(columnTypes["score"]).To(Equal("REAL"))
+		Expect(columnTypes["active"]).To(Equal("INTEGER"))
+	})
+
+	It("should handle empty rows", func() {
+		rows := []QueryResultRow{}
+		columnTypes := InferColumnTypes(rows)
+		Expect(columnTypes).To(HaveLen(0))
+	})
+})


### PR DESCRIPTION
gorm's `.Create(map[string]any)` would panic if the value was not a primitive type.