### PR TITLE
fix: reading view table into go types

### DIFF
--- a/view/columns.go
+++ b/view/columns.go
@@ -97,7 +97,7 @@ func (c ViewColumnDefList) ToColumnTypeMap() map[string]models.ColumnType {
 		case ColumnTypeBytes:
 			return col.Name, models.ColumnTypeString
 		case ColumnTypeMillicore:
-			return col.Name, models.ColumnTypeInteger
+			return col.Name, models.ColumnTypeString
 		case ColumnTypeBoolean:
 			return col.Name, models.ColumnTypeBoolean
 		case ColumnTypeDateTime:

--- a/view/db.go
+++ b/view/db.go
@@ -182,6 +182,10 @@ func getAtlasType(colType ColumnType) schema.Type {
 		return &schema.StringType{T: "text"}
 	case ColumnTypeGauge:
 		return &schema.JSONType{T: "jsonb"}
+	case ColumnTypeBytes:
+		return &schema.StringType{T: "text"} // stored as text due to values like "250Mi"
+	case ColumnTypeMillicore:
+		return &schema.StringType{T: "text"}
 	default:
 		return &schema.StringType{T: "text"}
 	}


### PR DESCRIPTION
when reading from postgres table, we must convert the values into a type defined by the column.

Example: 
* type `gauge` is saved to db as JSONB. When the data is read, the postgres driver reads it into []uint8. We need to convert that to json.RawMessage or types.JSON() for proper serialization to the web client.
* type `duration` is saved as bigint. When the data is read, it must be casted to time.Duration()