### PR TITLE
fix: handle ResetIsPushed for view_panels

### DIFF
--- a/upstream/jobs.go
+++ b/upstream/jobs.go
@@ -382,6 +382,7 @@ func ResetIsPushed(ctx context.Context) error {
 		models.ConfigChange{}.TableName():   fmt.Sprintf(`created_at >= NOW() - INTERVAL '%d days'`, intervalDays),
 		models.CheckStatus{}.TableName():    fmt.Sprintf(`created_at >= NOW() - INTERVAL '%d days'`, intervalDays),
 		models.JobHistory{}.TableName():     fmt.Sprintf(`time_start >= NOW() - INTERVAL '%d days'`, intervalDays),
+		models.ViewPanel{}.TableName():      fmt.Sprintf(`refreshed_at >= NOW() - INTERVAL '%d days'`, intervalDays),
 	}
 
 	defQuery := fmt.Sprintf(`created_at >= NOW() - INTERVAL '%d days' OR updated_at >= NOW() - INTERVAL '%d days'`, intervalDays, intervalDays)
@@ -397,7 +398,7 @@ func ResetIsPushed(ctx context.Context) error {
 			if err := ctx.DB().Table(table.TableName()).
 				Where(lo.CoalesceOrEmpty(overrides[table.TableName()], defQuery)).
 				Update("is_pushed", false).Error; err != nil {
-				errs = append(errs, fmt.Errorf("error updating is_pushed for table[%s]: %w", table, err))
+				errs = append(errs, fmt.Errorf("error updating is_pushed for table[%s]: %w", table.TableName(), err))
 			}
 		}
 	}


### PR DESCRIPTION
```
{"time":"2025-09-05T03:16:25.819249545Z","level":"ERROR","msg":"ERROR >=\u001b[33m[3ms] \u001b[34;1m[rows:0]\u001b[0m ERROR: column \"created_at\" does not exist (SQLSTATE 42703) UPDATE \"view_panels\" SET \"is_pushed\"=$1$ WHERE created_at >= NOW() - INTERVAL '7 days' OR updated_at >= NOW() - INTERVAL '7 days' AND deleted_at IS NULL","logger":"db"}
{"time":"2025-09-05T03:16:25.819487873Z","level":"ERROR","msg":"ResetIsPushed{https://mc.org-t7jalrtfpbbl.workload-prod-eu-01.flanksource.com} error updating is_pushed for table[{00000000-0000-0000-0000-000000000000  00000000-0000-0000-0000-000000000000 %!s(bool=false) <nil> }]: ERROR: column \"created_at\" does not exist (SQLSTATE 42703)","logger":"job. reset is pushed"}
```