### PR TITLE
feat(resource selector): Support for playbooks and connections

### DIFF
--- a/query/connections.go
+++ b/query/connections.go
@@ -1,0 +1,26 @@
+package query
+
+import (
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/google/uuid"
+)
+
+func FindConnectionIDsByResourceSelector(ctx context.Context, limit int, resourceSelectors ...types.ResourceSelector) ([]uuid.UUID, error) {
+	return queryTableWithResourceSelectors(ctx, "connections", limit, resourceSelectors...)
+}
+
+func FindConnectionsByResourceSelector(ctx context.Context, limit int, resourceSelectors ...types.ResourceSelector) ([]models.Connection, error) {
+	ids, err := queryTableWithResourceSelectors(ctx, "connections", limit, resourceSelectors...)
+	if err != nil {
+		return nil, err
+	}
+
+	var connections []models.Connection
+	if err := ctx.DB().Where("id IN ?", ids).Find(&connections).Error; err != nil {
+		return nil, err
+	}
+
+	return connections, nil
+}

--- a/query/models.go
+++ b/query/models.go
@@ -255,6 +255,11 @@ var PlaybookQueryModel = QueryModel{
 	},
 }
 
+var ConnectionQueryModel = QueryModel{
+	Table:   models.Connection{}.TableName(),
+	Columns: []string{"id", "name", "namespace", "type"},
+}
+
 var ConfigChangeQueryModel = QueryModel{
 	Table: "catalog_changes",
 	Columns: []string{
@@ -296,6 +301,8 @@ func GetModelFromTable(table string) (QueryModel, error) {
 		return CheckQueryModel, nil
 	case models.Playbook{}.TableName():
 		return PlaybookQueryModel, nil
+	case models.Connection{}.TableName():
+		return ConnectionQueryModel, nil
 	case models.CatalogChange{}.TableName():
 		return ConfigChangeQueryModel, nil
 	case models.ConfigItemSummary{}.TableName():

--- a/tests/fixtures/dummy/all.go
+++ b/tests/fixtures/dummy/all.go
@@ -22,7 +22,8 @@ type DummyData struct {
 	People []models.Person
 	Agents []models.Agent
 
-	Playbooks []models.Playbook
+	Playbooks   []models.Playbook
+	Connections []models.Connection
 
 	Topologies             []models.Topology
 	Components             []models.Component
@@ -79,6 +80,10 @@ func (t *DummyData) Populate(ctx context.Context) error {
 	}
 
 	if err := gormDB.CreateInBatches(t.Playbooks, 100).Error; err != nil {
+		return err
+	}
+
+	if err := gormDB.CreateInBatches(t.Connections, 100).Error; err != nil {
 		return err
 	}
 
@@ -295,6 +300,10 @@ func (t *DummyData) Delete(gormDB *gorm.DB) error {
 		return err
 	}
 
+	if err := DeleteAll(gormDB, t.Connections); err != nil {
+		return err
+	}
+
 	if err := DeleteAll(gormDB, t.Teams); err != nil {
 		return err
 	}
@@ -331,6 +340,7 @@ func GetStaticDummyData(db *gorm.DB) DummyData {
 	// we're appending here so we do not mutate the original slice.
 	d := DummyData{
 		Playbooks:                    append([]models.Playbook{}, AllDummyPlaybooks...),
+		Connections:                  append([]models.Connection{}, AllDummyConnections...),
 		People:                       append([]models.Person{}, AllDummyPeople...),
 		Agents:                       append([]models.Agent{}, AllDummyAgents...),
 		Topologies:                   append([]models.Topology{}, AllDummyTopologies...),

--- a/tests/fixtures/dummy/connections.go
+++ b/tests/fixtures/dummy/connections.go
@@ -1,0 +1,25 @@
+package dummy
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/flanksource/duty/models"
+)
+
+var AWSConnection = models.Connection{
+	ID:        uuid.MustParse("6c4c4c4c-0000-0000-0000-000000000001"),
+	Name:      "aws-connection",
+	Namespace: "default",
+	Source:    models.SourceConfigFile,
+	Type:      "aws",
+}
+
+var PostgresConnection = models.Connection{
+	ID:        uuid.MustParse("6c4c4c4c-0000-0000-0000-000000000002"),
+	Name:      "postgres-connection",
+	Namespace: "production",
+	Source:    models.SourceConfigFile,
+	Type:      "postgres",
+}
+
+var AllDummyConnections = []models.Connection{AWSConnection, PostgresConnection}

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -58,6 +58,8 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 		Components    []models.Component
 		Checks        []models.Check
 		ConfigChanges []models.CatalogChange
+		Playbooks     []models.Playbook
+		Connections   []models.Connection
 	}{
 		{
 			description: "id",
@@ -258,6 +260,41 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 			},
 			ConfigChanges: []models.CatalogChange{eksClusterCatalogChange},
 		},
+		{
+			description: "playbook by id",
+			query: query.SearchResourcesRequest{
+				Playbooks: []types.ResourceSelector{{ID: dummy.EchoConfig.ID.String()}},
+			},
+			Playbooks: []models.Playbook{dummy.EchoConfig},
+		},
+		{
+			description: "playbook by name and namespace",
+			query: query.SearchResourcesRequest{
+				Playbooks: []types.ResourceSelector{{Name: dummy.EchoConfig.Name, Namespace: dummy.EchoConfig.Namespace}},
+			},
+			Playbooks: []models.Playbook{dummy.EchoConfig},
+		},
+		{
+			description: "connection by id",
+			query: query.SearchResourcesRequest{
+				Connections: []types.ResourceSelector{{ID: dummy.AWSConnection.ID.String()}},
+			},
+			Connections: []models.Connection{dummy.AWSConnection},
+		},
+		{
+			description: "connection by type",
+			query: query.SearchResourcesRequest{
+				Connections: []types.ResourceSelector{{Types: []string{dummy.AWSConnection.Type}}},
+			},
+			Connections: []models.Connection{dummy.AWSConnection},
+		},
+		{
+			description: "connection by namespace",
+			query: query.SearchResourcesRequest{
+				Connections: []types.ResourceSelector{{Namespace: dummy.PostgresConnection.Namespace}},
+			},
+			Connections: []models.Connection{dummy.PostgresConnection},
+		},
 	}
 
 	ginkgo.Describe("search", ginkgo.Ordered, func() {
@@ -294,6 +331,8 @@ var _ = ginkgo.Describe("Search Properties", ginkgo.Ordered, ginkgo.Pending, fun
 		Components    []models.Component
 		Checks        []models.Check
 		ConfigChanges []models.CatalogChange
+		Playbooks     []models.Playbook
+		Connections   []models.Connection
 	}{
 		{
 			description: "field selector | Property lookup | configs",
@@ -337,6 +376,8 @@ var _ = ginkgo.Describe("Search Properties", ginkgo.Ordered, ginkgo.Pending, fun
 			Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Components...)), "should contain components")
 			Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Checks...)), "should contain checks")
 			Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.ConfigChanges...)), "should contain config changes")
+			Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Playbooks...)), "should contain playbooks")
+			Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Connections...)), "should contain connections")
 		})
 	}
 })


### PR DESCRIPTION
related: https://github.com/flanksource/flanksource-ui/pull/2635

we need this to support the search queries in resources field in the permission table.
Example: Search connections by type=aws