### PR TITLE
feat: RLS canaries

### DIFF
--- a/canary/controller.go
+++ b/canary/controller.go
@@ -1,0 +1,41 @@
+package canary
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/flanksource/duty/api"
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/query"
+)
+
+type SummaryResponse struct {
+	Duration      int                   `json:"duration,omitempty"`
+	RunnerName    string                `json:"runnerName"`
+	ChecksSummary []models.CheckSummary `json:"checks_summary,omitempty"`
+}
+
+func SummaryHandler(c echo.Context) error {
+	ctx := c.Request().Context().(context.Context)
+
+	var queryOpt query.CheckSummaryOptions
+	if err := c.Bind(&queryOpt); err != nil {
+		return api.Errorf(api.EINVALID, "invalid request: %v", err)
+	}
+
+	start := time.Now()
+	results, err := query.CheckSummary(ctx, query.CheckSummaryOptions(queryOpt))
+	if err != nil {
+		return api.Errorf(api.EINTERNAL, "failed to get check summary: %v", err)
+	}
+
+	apiResponse := &SummaryResponse{
+		RunnerName:    "local", // TODO: We don't have runnerName in here that canary-checker users
+		ChecksSummary: results,
+		Duration:      int(time.Since(start).Milliseconds()),
+	}
+	return c.JSON(http.StatusOK, apiResponse)
+}

--- a/query/check_summary.go
+++ b/query/check_summary.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"gorm.io/gorm"
 )
 
@@ -80,17 +80,17 @@ func CheckSummary(ctx context.Context, opts ...CheckSummaryOptions) ([]models.Ch
 
 	query := fmt.Sprintf(`SELECT json_agg(%s) FROM check_summary AS result WHERE deleted_at is null`, selectField)
 
-	args := pgx.NamedArgs{}
+	var args []any
 	if opt.DeleteFrom != nil {
 		query += " OR deleted_at > @from"
-		args["from"] = *opt.DeleteFrom
+		args = append(args, sql.Named("from", *opt.DeleteFrom))
 	}
 	if opt.Labels != nil {
 		query += " AND labels @> @labels"
-		args["labels"] = opt.Labels
+		args = append(args, sql.Named("labels", opt.Labels))
 	}
 
-	rows, err := ctx.Pool().Query(ctx, query, args)
+	rows, err := ctx.DB().Raw(query, args...).Rows()
 	if err != nil {
 		return nil, err
 	}
@@ -98,13 +98,18 @@ func CheckSummary(ctx context.Context, opts ...CheckSummaryOptions) ([]models.Ch
 
 	var results []models.CheckSummary
 	for rows.Next() {
-		var summaries []models.CheckSummary
-		if rows.RawValues()[0] == nil {
+		var jsonData []byte
+		if err := rows.Scan(&jsonData); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if jsonData == nil {
 			continue
 		}
 
-		if err := json.Unmarshal(rows.RawValues()[0], &summaries); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal components:%v for %s", err, rows.RawValues()[0])
+		var summaries []models.CheckSummary
+		if err := json.Unmarshal(jsonData, &summaries); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal components: %w", err)
 		}
 
 		results = append(results, summaries...)


### PR DESCRIPTION
For now: setup RLS on canaries on labels because we don't have `tags` and `agent_id` on canaries.

This effectively hides all canaries for the guest user (for now)
