### PR TITLE
fix: add CHECK constraint to prevent permissions with both object_selector and resource IDs

### DIFF
--- a/schema/permissions.hcl
+++ b/schema/permissions.hcl
@@ -158,6 +158,11 @@ table "permissions" {
   primary_key {
     columns = [column.id]
   }
+
+  check "permissions_selector_or_id_check" {
+    expr = "(object_selector IS NOT NULL)::int + (config_id IS NOT NULL)::int + (playbook_id IS NOT NULL)::int + (canary_id IS NOT NULL)::int + (component_id IS NOT NULL)::int + (connection_id IS NOT NULL)::int = 1"
+  }
+
   foreign_key "permissions_playbook_id_fkey" {
     columns     = [column.playbook_id]
     ref_columns = [table.playbooks.column.id]


### PR DESCRIPTION
There was a bug in UI that was creating invalid permissions.

Add a hard constraint on the DB layer.

```
policy [p ebc56086-91e5-4e44-8f0f-58fda8fbeffb * read allow matchResourceSelector(r.obj, 'eyJjb25maWdzIjpbeyJ0YWdTZWxlY3RvciI6ImNsdXN0ZXI9aG9tZWxhYixuYW1lc3BhY2U9bW9uaXRvcmluZyJ9XSwic2NvcGVzIjpbeyJuYW1lc3BhY2UiOiJtYyIsIm5hbWUiOiJob21lbGFiLW1vbml0b3JpbmctY29uZmlncyJ9XX0=') && str(r.obj.Config.ID) == "e397988a-c9a1-4d9f-a219-42e6add139db" 0199cde9-a3bc-ea3f-9d47-144d07ca069b]
```

A policy like this was generated