### PR TITLE
fix: prevent ABAC policy condition evaluation on RBAC checks

### DIFF
--- a/rbac/custom_functions.go
+++ b/rbac/custom_functions.go
@@ -81,6 +81,17 @@ func matchResourceSelectorPair(pair resourcePair) bool {
 }
 
 func AddCustomFunctions(enforcer addableEnforcer) {
+	// This is used in the Casbin matcher to differentiate between RBAC checks (string objects)
+	// and ABAC checks (ABACAttribute objects).
+	enforcer.AddFunction("isString", func(args ...any) (any, error) {
+		if len(args) != 1 {
+			return false, fmt.Errorf("isString needs 1 argument. got %d", len(args))
+		}
+
+		_, ok := args[0].(string)
+		return ok, nil
+	})
+
 	enforcer.AddFunction("matchResourceSelector", func(args ...any) (any, error) {
 		if len(args) != 2 {
 			return false, fmt.Errorf("matchResourceSelector needs 2 arguments. got %d", len(args))

--- a/rbac/enforcer_test.go
+++ b/rbac/enforcer_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/casbin/casbin/v2"
 	casbinModel "github.com/casbin/casbin/v2/model"
 	stringadapter "github.com/casbin/casbin/v2/persist/string-adapter"
-	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
+
+	"github.com/flanksource/duty/models"
 )
 
 func NewEnforcer(policy string) (*casbin.Enforcer, error) {
@@ -30,6 +31,8 @@ p, johndoe, *, playbook:run, allow, r.obj.Playbook.Name == 'scale-deployment' , 
 p, johndoe, *, playbook:run, deny, r.obj.Playbook.Name == 'delete-deployment' , na
 p, johndoe, *, playbook:run, allow, r.obj.Playbook.Name == 'restart-deployment' && r.obj.Config.Tags.namespace == 'default' , na
 p, alice, *, playbook:run, deny, r.obj.Playbook.Name == 'restart-deployment' && r.obj.Config.Tags.namespace == 'default', na
+p, johndoe, *, read, allow, r.obj.Playbook.Name == 'echo', na
+p, bob, catalog, read, allow, , na
 `
 
 	var userID = uuid.New()
@@ -103,6 +106,34 @@ p, alice, *, playbook:run, deny, r.obj.Playbook.Name == 'restart-deployment' && 
 			obj:         "catalog",
 			act:         "read",
 			allowed:     false,
+		},
+		{
+			description: "RBAC check with string object should not crash when ABAC policies with conditions exist (issue #2428)",
+			user:        "johndoe",
+			obj:         "views",
+			act:         "read",
+			allowed:     false,
+		},
+		{
+			description: "RBAC check with string object (catalog) should work despite ABAC conditions",
+			user:        "johndoe",
+			obj:         "catalog",
+			act:         "read",
+			allowed:     false,
+		},
+		{
+			description: "RBAC check with string object (playbooks) should work despite ABAC conditions",
+			user:        "alice",
+			obj:         "playbooks",
+			act:         "read",
+			allowed:     false,
+		},
+		{
+			description: "RBAC check with string object should pass when matching simple policy (no condition)",
+			user:        "bob",
+			obj:         "catalog",
+			act:         "read",
+			allowed:     true,
 		},
 	}
 

--- a/rbac/model.ini
+++ b/rbac/model.ini
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && (p.obj == '*' || r.obj == p.obj) && (p.act == '*' || r.act == p.act) && (p.condition == '' || eval(p.condition))
+m = g(r.sub, p.sub) && (p.obj == '*' || r.obj == p.obj) && (p.act == '*' || r.act == p.act) && (p.condition == '' || (!isString(r.obj) && eval(p.condition)))

--- a/rbac/policy/policy.go
+++ b/rbac/policy/policy.go
@@ -74,9 +74,9 @@ func (acl ACL) GetPolicyDefinition() [][]string {
 	for _, object := range strings.Split(acl.Objects, ",") {
 		for _, action := range strings.Split(acl.Actions, ",") {
 			if strings.HasPrefix(action, "!") {
-				definitions = append(definitions, []string{acl.Principal, object, action[1:], "deny", "true", "na"})
+				definitions = append(definitions, []string{acl.Principal, object, action[1:], "deny", "", "na"})
 			} else {
-				definitions = append(definitions, []string{acl.Principal, object, action, "allow", "true", "na"})
+				definitions = append(definitions, []string{acl.Principal, object, action, "allow", "", "na"})
 			}
 		}
 	}


### PR DESCRIPTION
ABAC policies with conditions (e.g., r.obj.Playbook.Name == 'echo') would
crash when evaluated during RBAC checks with string objects. The matcher now
skips ABAC condition evaluation for RBAC checks using an isString() check.

Also cleaned up default policies to use empty condition instead of "true" for
clearer intent.

Fixes #2428
