### PR TITLE
fix: Permission -> casbin policy formation

### DIFF
--- a/rbac/policy/policy.go
+++ b/rbac/policy/policy.go
@@ -136,7 +136,7 @@ func (p Permission) ToArgsWithoutSubject() []string {
 		p.Object,
 		p.Action,
 		lo.Ternary(p.Deny, "deny", ""),
-		lo.Ternary(p.Condition != "", p.Condition, "true"),
+		lo.Ternary(p.Condition != "", p.Condition, ""),
 		lo.Ternary(p.ID != "", p.ID, "na"),
 	}
 }


### PR DESCRIPTION
we don't need "true" as the condition.
the casbin model does a condition == "" check.
