### PR TITLE
fix: set mountpoint for git checkout case

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -149,9 +149,12 @@ func RunCmd(ctx context.Context, exec Exec, cmd *osExec.Cmd) (*ExecDetails, erro
 		if err != nil {
 			return nil, ctx.Oops().Wrap(err)
 		}
-		cmdDir := path.Join(properties.String(cwd, "shell.tmp.dir"), "shell-tmp", uuid.New().String())
-		if err := os.MkdirAll(cmdDir, 0700); err != nil {
-			return nil, ctx.Oops().Wrap(err)
+		cmdDir := envParams.mountPoint
+		if cmdDir == "" {
+			cmdDir = path.Join(properties.String(cwd, "shell.tmp.dir"), "shell-tmp", uuid.New().String())
+			if err := os.MkdirAll(cmdDir, 0700); err != nil {
+				return nil, ctx.Oops().Wrap(err)
+			}
 		}
 		cmd.Dir = cmdDir
 	} else {


### PR DESCRIPTION
exec checkout test in canary-checker is failing due to incorrect cmd.Dir 