### PR TITLE
test: add prepareEnvironment test for git checkout validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ nohup.out
 .cursor/
 .db/
 __debug_bin*
+
+# This is where shell tests clone the checkout repository
+exec-checkout/


### PR DESCRIPTION
Adds test coverage for the prepareEnvironment function to verify git repository checkout behavior, mount point creation, and metadata tracking.