### PR TITLE
fix(views): Don't manage a generated view table's updated_at column

### DIFF
--- a/views/013_updated_at_column_trigger.sql
+++ b/views/013_updated_at_column_trigger.sql
@@ -47,7 +47,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Iterate over all tables (excluding views) in the current schema and
+-- Iterate over all tables (excluding postgres views and the generated view tables) in the current schema and
 -- create a trigger on each table that has an "updated_at" column
 DO $$
 DECLARE
@@ -60,6 +60,7 @@ BEGIN
       table_schema = current_schema()
       AND column_name = 'updated_at'
       AND table_name NOT IN (SELECT table_name FROM information_schema.views WHERE table_schema = current_schema())
+      AND table_name NOT LIKE 'view_%' -- these are generated_view tables. We don't manage its updated_at column.
   LOOP
     EXECUTE format('CREATE OR REPLACE TRIGGER %I_update_updated_at
       BEFORE UPDATE ON %I


### PR DESCRIPTION
`updated_at` column in view's generated table is a derived column. We shouldn't be managing it.

Also, the schema is very dynamic for the generated table. We don't want the trigger to stay on (if) after `udpated_at` column is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database trigger configuration by refining exclusion criteria to properly handle system tables and generated structures, ensuring automatic timestamp updates work reliably across all applicable data tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->