### PR TITLE
chore: switch to using SECURITY DEFINER fns for refreshing materialized views

### DIFF
--- a/job/check_status.go
+++ b/job/check_status.go
@@ -10,15 +10,15 @@ import (
 )
 
 func RefreshCheckSizeSummary(ctx context.Context) error {
-	return ctx.DB().Exec("REFRESH MATERIALIZED VIEW check_size_summary").Error
+	return ctx.DB().Exec("SELECT refresh_check_size_summary()").Error
 }
 
 func RefreshCheckStatusSummary(ctx context.Context) error {
-	return ctx.DB().Exec("REFRESH MATERIALIZED VIEW check_status_summary").Error
+	return ctx.DB().Exec("SELECT refresh_check_status_summary()").Error
 }
 
 func RefreshCheckStatusSummaryAged(ctx context.Context) error {
-	return ctx.DB().Exec("REFRESH MATERIALIZED VIEW check_status_summary_aged").Error
+	return ctx.DB().Exec(" SELECT refresh_check_status_summary_aged()").Error
 }
 
 func DeleteOldCheckStatuses(ctx context.Context, retention int) (int, error) {

--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -34,9 +34,14 @@ LEFT JOIN
 GROUP BY
     ci.id, ci.name;
 
+CREATE OR REPLACE FUNCTION refresh_config_item_summary_3d() RETURNS VOID AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW  config_item_summary_3d;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS
-  config_item_summary_7d AS
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS  config_item_summary_7d AS
 WITH type_counts AS (
     SELECT
         ca.config_id,
@@ -64,8 +69,14 @@ LEFT JOIN
 GROUP BY
     ci.id, ci.name;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS
-  config_item_summary_30d AS
+
+CREATE OR REPLACE FUNCTION refresh_config_item_summary_7d() RETURNS VOID AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW  config_item_summary_7d;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS config_item_summary_30d AS
 WITH type_counts AS (
     SELECT
         ca.config_id,
@@ -92,6 +103,14 @@ LEFT JOIN
     config_changes cc ON ci.id = cc.config_id AND cc.created_at >= NOW() - INTERVAL '30 days'
 GROUP BY
     ci.id, ci.name;
+
+
+
+CREATE OR REPLACE FUNCTION refresh_config_item_summary_30d() RETURNS VOID AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW  config_item_summary_30d;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 CREATE or REPLACE VIEW configs AS
   SELECT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database functions for refreshing configuration summary data across multiple time windows (3-day, 7-day, 30-day).
  * Added database functions for refreshing check status and check size summary data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->