### PR TITLE
fix: do not double modify deleted_at

### DIFF
--- a/views/013_updated_at_column_trigger.sql
+++ b/views/013_updated_at_column_trigger.sql
@@ -12,10 +12,11 @@ BEGIN
   oldrow = hstore(OLD.*);
 
   IF to_jsonb(NEW) ? 'deleted_at' THEN
-    -- If deleted_at is already set, do not modify it
-    IF OLD.deleted_at IS NOT NULL THEN
-        RETURN NEW;
+    -- Prevent changing deleted_at to a different non-null value
+    IF OLD.deleted_at IS NOT NULL AND NEW.deleted_at IS NOT NULL THEN
+      NEW.deleted_at := OLD.deleted_at;
     END IF;
+    -- Skip updated_at modification for soft-deleted records
     IF NEW.deleted_at IS NOT NULL THEN
       RETURN NEW;
     END IF;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of deletion timestamps during updates so the original deletion time is only preserved when both the existing and incoming records indicate deletion.
  * Maintains the early-return behavior for already-deleted records to avoid unintended additional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->