### PR TITLE
fix: add migration to update zero ts last_runtime

### DIFF
--- a/connection/gcs.go
+++ b/connection/gcs.go
@@ -41,7 +41,6 @@ func (g *GCSConnection) Client(ctx context.Context) (*gcs.Client, error) {
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		}
-
 		clientOpts = append(clientOpts, option.WithHTTPClient(insecureHTTPClient))
 	}
 

--- a/views/043_checks_unlogged_update_last_runtime.sql
+++ b/views/043_checks_unlogged_update_last_runtime.sql
@@ -1,0 +1,4 @@
+--
+UPDATE checks_unlogged
+SET last_runtime = NOW()
+WHERE EXTRACT(YEAR FROM last_runtime) = 1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated last_runtime timestamps in checks (unlogged) to the current time for records with invalid year values.

* **Style**
  * Minor whitespace/formatting adjustments with no user-visible behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->