### PR TITLE
Fix git clone fetch and ref selection

### DIFF
--- a/connection/git.go
+++ b/connection/git.go
@@ -113,7 +113,7 @@ func (gitClient *GitClient) Clone(ctx context.Context, dir string) (map[string]a
 			Force:     true,
 			Prune:     true,
 			Auth:      gitClient.Auth,
-			Depth:     gitClient.Depth}); err != nil {
+			Depth:     gitClient.Depth}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 			return extra, ctx.Oops().Wrapf(err, "error during git fetch")
 		}
 
@@ -127,7 +127,7 @@ func (gitClient *GitClient) Clone(ctx context.Context, dir string) (map[string]a
 			}
 
 			for _, ref := range list {
-				if strings.HasSuffix(ref.Name().String(), gitClient.Branch) {
+				if ref.Name().Short() == gitClient.Branch {
 					refName = ref.Name()
 					ctx.Logger.V(4).Infof("found ref %s matching %s", refName, gitClient.Branch)
 				}


### PR DESCRIPTION
* Handle already-up-to-date fetches without failing and select refs by exact short name rather than suffix matching.
* Prevents accidentally checking out refs like changeset-release/master when cloning master (e.g., the Backstage repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during repository synchronization to correctly identify fetch failures.
  * Enhanced branch reference matching logic for more accurate remote branch identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->