### PR TITLE
chore: add depth option for exec checkout

### DIFF
--- a/connection/git.go
+++ b/connection/git.go
@@ -171,6 +171,8 @@ type GitConnection struct {
 	// Type of connection e.g. github, gitlab
 	Type   string `yaml:"type,omitempty" json:"type,omitempty"`
 	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+
+	Depth int `json:"depth,omitempty"`
 	// Destination is the full path to where the contents of the URL should be downloaded to.
 	// If left empty, the sha256 hash of the URL will be used as the dir name.
 	//
@@ -263,7 +265,7 @@ func (c *GitConnection) HydrateConnection(ctx context.Context) error {
 func CreateGitConfig(ctx context.Context, conn *GitConnection) (*GitClient, error) {
 	config := &GitClient{
 		URL:    conn.URL,
-		Depth:  1,
+		Depth:  lo.CoalesceOrEmpty(conn.Depth, 1),
 		Branch: lo.CoalesceOrEmpty(conn.Branch, "main"),
 	}
 


### PR DESCRIPTION
Fixes: #1688 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Git depth setting so users can control clone depth. Defaults to shallow clones (depth = 1) when unspecified, but can be increased to fetch more history for workflows that require it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->