### PR TITLE
chore: update team name unique clause to handle deleted teams

### DIFF
--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -160,9 +160,10 @@ table "teams" {
   primary_key {
     columns = [column.id]
   }
-  index "team_name_deleted_at_key" {
+ index "team_name_key" {
     unique  = true
-    columns = [column.name, column.deleted_at]
+    columns = [column.name]
+    where   = "deleted_at IS NULL"
   }
   foreign_key "teams_created_by_fkey" {
     columns     = [column.created_by]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated team-name uniqueness so the constraint ignores soft-deleted records (deleted teams no longer block reuse of the same name), reducing conflicts when names are reused and aligning behavior with soft-delete handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->