### PR TITLE
feat: notification resource type

### DIFF
--- a/functions/drop.sql
+++ b/functions/drop.sql
@@ -6,6 +6,10 @@ DROP VIEW IF EXISTS config_tags CASCADE;
 
 DROP VIEW IF EXISTS config_detail CASCADE;
 
+DROP VIEW IF EXISTS notification_send_history_resource_tags;
+
+DROP VIEW IF EXISTS notification_send_history_resource_types;
+
 DROP VIEW IF EXISTS notification_send_history_summary;
 
 DROP VIEW IF EXISTS user_config_access_summary;

--- a/query/notification_types.go
+++ b/query/notification_types.go
@@ -19,8 +19,10 @@ const notificationSummaryPageSizeDefault = 50
 type NotificationResourceKind string
 
 const (
-	NotificationResourceKindConfig = "config"
-	NotificationResourceKindCheck  = "checks"
+	NotificationResourceKindConfig    = "config"
+	NotificationResourceKindCheck     = "check"
+	NotificationResourceKindComponent = "component"
+	NotificationResourceKindCanary    = "canary"
 )
 
 type NotificationSendHistorySummaryRequest struct {

--- a/rbac/objects.go
+++ b/rbac/objects.go
@@ -123,6 +123,7 @@ var dbResourceObjMap = map[string]string{
 	"notification_send_history":                 policy.ObjectMonitor,
 	"notification_send_history_resources":       policy.ObjectMonitor,
 	"notification_send_history_resource_tags":   policy.ObjectMonitor,
+	"notification_send_history_resource_types":  policy.ObjectMonitor,
 	"notification_send_history_summary":         policy.ObjectMonitor,
 	"rpc/notification_send_history_of_resource": policy.ObjectMonitor,
 	"notifications_summary":                     policy.ObjectMonitor,

--- a/tests/query_notification_summary_test.go
+++ b/tests/query_notification_summary_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"time"
 
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/tests/fixtures/dummy"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 type NotificationSummaryGroupByResource struct {
@@ -82,7 +83,7 @@ var _ = ginkgo.Describe("Notification Summary", ginkgo.Ordered, ginkgo.Serial, f
 	ginkgo.It("should return the correct notification summary", func() {
 		request := query.NotificationSendHistorySummaryRequest{
 			Search:       *dummy.LogisticsAPIPodConfig.Name,
-			ResourceType: "config",
+			ResourceKind: query.NotificationResourceKindConfig,
 			From:         "now-18m",
 		}
 		notificationSummary, err := query.NotificationSendHistorySummary(DefaultContext, request)

--- a/views/021_notification.sql
+++ b/views/021_notification.sql
@@ -151,6 +151,8 @@ $$
 LANGUAGE plpgsql;
 
 ---
+DROP VIEW IF EXISTS notification_send_history_resource_tags;
+DROP VIEW IF EXISTS notification_send_history_resource_types;
 DROP VIEW IF EXISTS notification_send_history_summary;
 DROP VIEW IF EXISTS notification_send_history_resources;
 
@@ -242,21 +244,25 @@ LEFT JOIN notification_send_history_resources AS "nsh_resources" ON notification
 LEFT JOIN config_items ON nsh_resources.resource_kind = 'config' AND config_items.id = notification_send_history.resource_id;
 
 --- notification_send_history_resource_tags
-DROP VIEW IF EXISTS notification_send_history_resource_tags;
-
 CREATE OR REPLACE VIEW notification_send_history_resource_tags AS
-WITH config_resources AS (
-  SELECT DISTINCT config_items.tags
-  FROM notification_send_history
-  JOIN config_items ON config_items.id = notification_send_history.resource_id
-  WHERE notification_send_history.source_event LIKE 'config.%'
-    AND config_items.deleted_at IS NULL
+WITH resource_tag_sets AS (
+  SELECT DISTINCT resource_tags
+  FROM notification_send_history_summary
+  WHERE resource_tags IS NOT NULL
 )
 SELECT d.key, d.value
-FROM config_resources
-JOIN json_each_text(config_resources.tags::json) d ON TRUE
+FROM resource_tag_sets
+JOIN json_each_text(resource_tag_sets.resource_tags::json) d ON TRUE
 GROUP BY d.key, d.value
 ORDER BY d.key, d.value;
+
+--- notification_send_history_resource_types
+CREATE OR REPLACE VIEW notification_send_history_resource_types AS
+SELECT DISTINCT
+  resource_type
+FROM notification_send_history_summary
+WHERE resource_type IS NOT NULL
+ORDER BY resource_type;
 
 -- Insert notification_send_history updates as config_changes
 CREATE OR REPLACE FUNCTION insert_notification_history_config_change()


### PR DESCRIPTION
- **feat: add resource_type to notification send history summary**
- **feat: add CREATE OR REPLACE VIEW notification_send_history_resource_tags AS  and notification_send_history_resource_types**


related: https://github.com/flanksource/flanksource-ui/issues/2818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications can be filtered, grouped and reported by resource kind (Config, Check, Component, Canary).
  * Summary output now includes resource kind while preserving resource type where applicable; distinct resource types are exposed for improved reporting.

* **Tests**
  * Tests updated to use the new resource-kind request field.

* **Chores**
  * Access control mappings updated to include notification send history resource types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->