### PR TITLE
chore: make external user aliases globally unique

### DIFF
--- a/schema/config_access.hcl
+++ b/schema/config_access.hcl
@@ -2,7 +2,7 @@ table "external_users" {
   schema = schema.public
   column "id" {
     null    = false
-    type = uuid
+    type    = uuid
     default = sql("generate_ulid()")
   }
   column "account_id" {
@@ -51,13 +51,18 @@ table "external_users" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "external_users_aliases_key" {
+    unique  = true
+    columns = [column.aliases]
+    where   = "deleted_at IS NULL"
+  }
 }
 
 table "external_groups" {
   schema = schema.public
   column "id" {
     null    = false
-    type = uuid
+    type    = uuid
     default = sql("generate_ulid()")
   }
   column "account_id" {
@@ -142,7 +147,7 @@ table "external_roles" {
   schema = schema.public
   column "id" {
     null    = false
-    type = uuid
+    type    = uuid
     default = sql("generate_ulid()")
 
   }
@@ -250,6 +255,7 @@ table "config_access" {
   column "id" {
     type    = text
     comment = "not a uuid. depends on the source. example: Microsoft has 0Tr1liTQeU2nA2LDmGCS4qwxw-A6_GhNos_LscLVs6w"
+    default = sql("generate_ulid()")
   }
   column "config_id" {
     type = uuid


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External users now support aliases with automatic normalization (lowercased and deduplicated)
  * Aliases enforced as unique across users, with case-insensitive matching
  * Config access records now receive auto-generated identifiers

* **Tests**
  * Added comprehensive test coverage for aliases functionality, including normalization, constraints, and edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->