### PR TITLE
fix: add scraper_id to config_access_summary join condition

### DIFF
--- a/views/038_config_access.sql
+++ b/views/038_config_access.sql
@@ -67,8 +67,14 @@ FROM config_access_unwrapped
 JOIN config_items ON config_access_unwrapped.config_id = config_items.id
 JOIN external_users ON config_access_unwrapped.external_user_id = external_users.id
 LEFT JOIN external_roles ON config_access_unwrapped.external_role_id = external_roles.id
-LEFT JOIN config_access_logs 
-  ON config_access_unwrapped.config_id = config_access_logs.config_id 
-  AND config_access_unwrapped.external_user_id = config_access_logs.external_user_id
-  AND config_access_unwrapped.scraper_id = config_access_logs.scraper_id
+LEFT JOIN LATERAL (
+  SELECT created_at 
+  FROM config_access_logs 
+  WHERE config_access_logs.config_id = config_access_unwrapped.config_id 
+    AND config_access_logs.external_user_id = config_access_unwrapped.external_user_id
+    AND (config_access_unwrapped.scraper_id IS NULL 
+         OR config_access_logs.scraper_id = config_access_unwrapped.scraper_id)
+  ORDER BY created_at DESC
+  LIMIT 1
+) config_access_logs ON true
 WHERE config_access_unwrapped.deleted_at IS NULL;


### PR DESCRIPTION
The `config_access_summary` view was missing `scraper_id` in the JOIN to `config_access_logs`, which could cause duplicate rows when a user has access logs from multiple scrapers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access history now uses the most recent log entry per configuration and user, improving accuracy when multiple logs exist.

* **New Features**
  * Config access summary now exposes more details: config identifiers and type, group/user identifiers, role, email, creation/deletion timestamps, last sign-in, last review timestamps, and reviewer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->