### PR TITLE
feat: add diverse labels to dummy checks for metrics filtering tests

### DIFF
--- a/tests/fixtures/dummy/checks.go
+++ b/tests/fixtures/dummy/checks.go
@@ -16,7 +16,13 @@ var LogisticsAPIHealthHTTPCheck = models.Check{
 	Type:     "http",
 	Status:   "healthy",
 	Labels: map[string]string{
-		"app": "logistics",
+		"app":       "logistics",
+		"cluster":   "production-us",
+		"namespace": "logistics",
+		"env":       "production",
+		"region":    "us-east-1",
+		"pod":       "logistics-api-7b9d4f5c6-x2k4m",
+		"pod_hash":  "7b9d4f5c6",
 	},
 }
 
@@ -27,7 +33,12 @@ var LogisticsAPIHomeHTTPCheck = models.Check{
 	Type:     "http",
 	Status:   "healthy",
 	Labels: map[string]string{
-		"app": "logistics",
+		"app":       "logistics",
+		"cluster":   "production-us",
+		"namespace": "logistics",
+		"env":       "production",
+		"instance":  "i-0abc123def456",
+		"revision":  "12345",
 	},
 }
 
@@ -38,7 +49,11 @@ var LogisticsDBCheck = models.Check{
 	Type:     "postgres",
 	Status:   "unhealthy",
 	Labels: map[string]string{
-		"app": "logistics",
+		"app":       "logistics",
+		"cluster":   "staging-eu",
+		"namespace": "logistics",
+		"env":       "staging",
+		"region":    "eu-west-1",
 	},
 }
 


### PR DESCRIPTION
Added realistic Kubernetes-style labels to dummy checks to enable testing of metrics label filtering (mission-control#2754):

- `pod_uid`, `container_uid` - to test `*uid*` pattern filtering
- `node_name`, `node_id` - to test `node_*` pattern filtering  
- `env`, `region` - general labels that should not be filtered

This enables testing `metrics.checks.labels=!*uid*,!node_*` configuration.