### PR TITLE
fix: send POST/PUT/PATCH body in HTTP dataquery

### DIFF
--- a/dataquery/http.go
+++ b/dataquery/http.go
@@ -62,24 +62,18 @@ func executeHTTPQuery(ctx context.Context, hq HTTPQuery) ([]QueryResultRow, erro
 
 	req := client.R(ctx)
 
-	if hq.Body != "" {
-		if err := req.Body(strings.NewReader(hq.Body)); err != nil {
-			return nil, fmt.Errorf("failed to set request body: %w", err)
-		}
-	}
-
 	var resp *commonshttp.Response
 	switch method {
 	case http.MethodGet:
 		resp, err = req.Get(url)
 	case http.MethodPost:
-		resp, err = req.Post(url, nil)
+		resp, err = req.Post(url, hq.Body)
 	case http.MethodPut:
-		resp, err = req.Put(url, nil)
+		resp, err = req.Put(url, hq.Body)
 	case http.MethodDelete:
 		resp, err = req.Delete(url)
 	case http.MethodPatch:
-		resp, err = req.Patch(url, nil)
+		resp, err = req.Patch(url, hq.Body)
 	default:
 		return nil, fmt.Errorf("unsupported http method: %s", method)
 	}

--- a/dataquery/http_test.go
+++ b/dataquery/http_test.go
@@ -178,6 +178,10 @@ func TestExecuteHTTPQuery_PostWithBody(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&body)
 		g.Expect(err).ToNot(HaveOccurred())
 
+		// Verify the POST body was sent correctly
+		g.Expect(body).To(HaveKeyWithValue("name", "test"))
+		g.Expect(body).To(HaveKeyWithValue("value", float64(42)))
+
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]any{
 			"received": body,


### PR DESCRIPTION
The request body was not being sent for POST, PUT, and PATCH requests
because nil was being passed to the HTTP client methods, overriding
the body that was set via req.Body(). Now passing hq.Body directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request body handling for POST, PUT, and PATCH operations.

* **Tests**
  * Enhanced validation tests for POST request body content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->