### PR TITLE
fix(notification): Undeprecate `body` field

### DIFF
--- a/models/notifications.go
+++ b/models/notifications.go
@@ -114,11 +114,11 @@ type NotificationSendHistory struct {
 	ID             uuid.UUID `json:"id,omitempty" gorm:"default:generate_ulid()"`
 	NotificationID uuid.UUID `json:"notification_id"`
 
-	// Deprecated: legacy rendered body kept for backward compatibility.
-	// New notifications no longer populate this field; use BodyPayload instead.
+	// Rendered body for raw/custom templates and existing clients.
+	// For clicky-based templates, use BodyPayload as the source of truth.
 	Body *string `json:"body,omitempty"`
 
-	// BodyPayload stores the clicky Schema + Data (source of truth).
+	// BodyPayload stores the clicky Schema + Data (source of truth for clicky templates).
 	BodyPayload types.JSON `json:"body_payload,omitempty" gorm:"column:body_payload"`
 
 	Error          *string   `json:"error,omitempty"`

--- a/schema/notifications.hcl
+++ b/schema/notifications.hcl
@@ -181,8 +181,9 @@ table "notification_send_history" {
     type = uuid
   }
   column "body" {
-    null = true # nullable for unsent notifications
-    type = text
+    null    = true # nullable for unsent notifications
+    type    = text
+    comment = "Rendered body for raw/custom templates and existing clients. Use body_payload for clicky-formatted notifications."
   }
   column "body_payload" {
     null    = true

--- a/views/021_notification.sql
+++ b/views/021_notification.sql
@@ -221,8 +221,6 @@ FROM canaries JOIN notification_send_history
 ON canaries.id = notification_send_history.resource_id AND notification_send_history.source_event LIKE 'canary.%';
 
 --- notification_send_history_summary
--- NOTE: notification_send_history.body is legacy and empty for new notifications.
--- Use body_payload for the source of truth.
 CREATE OR REPLACE VIEW notification_send_history_summary as
 SELECT 
   notification_send_history.*,
@@ -247,8 +245,6 @@ SELECT
 FROM notification_send_history
 LEFT JOIN notification_send_history_resources AS "nsh_resources" ON notification_send_history.resource_id = nsh_resources.id
 LEFT JOIN config_items ON nsh_resources.resource_kind = 'config' AND config_items.id = notification_send_history.resource_id;
-
-COMMENT ON COLUMN notification_send_history.body IS 'Deprecated: legacy rendered body; new notifications leave this field empty. Use body_payload instead.';
 
 --- notification_send_history_resource_tags
 CREATE OR REPLACE VIEW notification_send_history_resource_tags AS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved notification field documentation to clarify template usage patterns. Body field is designated for raw/custom templates and existing clients, while BodyPayload serves as the authoritative source for clicky-based template formatting with complete schema and data information. Removed related deprecation notices to provide clearer guidance for developers working with notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->