### PR TITLE
feat(schema): add source column to config_access table

### DIFF
--- a/models/config_access.go
+++ b/models/config_access.go
@@ -164,6 +164,7 @@ type ConfigAccess struct {
 	ID            string     `json:"id" gorm:"not null"`
 	ApplicationID *uuid.UUID `json:"application_id" gorm:"default:null"`
 	ScraperID     *uuid.UUID `json:"scraper_id" gorm:"default:null"`
+	Source        *string    `json:"source" gorm:"default:null"`
 
 	ConfigID        uuid.UUID  `json:"config_id"`
 	ExternalUserID  *uuid.UUID `json:"external_user_id,omitempty"`


### PR DESCRIPTION
```
The config_access table previously required every row to be owned by
either a scraper_id or an application_id (enforced by the
config_access_parent CHECK constraint). This made it impossible for
internal processes — like deriving playbook access from the RBAC
permission system — to write config_access entries without creating a
fake scraper or application as a parent. Using the auto generated system
scraper has the problem of the scraper run cleaning up stale items.

Add a 'source' column (nullable TEXT) that identifies the internal
process that produced an entry (e.g. 'rbac'). The CHECK constraint is
relaxed to: scraper_id IS NOT NULL OR application_id IS NOT NULL OR
source IS NOT NULL.

Existing rows are unaffected (source defaults to NULL, and they already
satisfy the constraint via scraper_id or application_id).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source tracking to configuration access records, enabling better identification of access origins (from integrations, applications, or internal systems).

* **Improvements**
  * Enhanced data integrity validation for access ownership.
  * Optimized performance for role-based access control queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->