### PR TITLE
fix(schema): add missing FK indexes and constraints

### DIFF
--- a/schema/agents.hcl
+++ b/schema/agents.hcl
@@ -102,6 +102,10 @@ table "agents" {
     columns = [column.name]
   }
 
+  index "agents_created_by_idx" {
+    columns = [column.created_by]
+  }
+
   foreign_key "agents_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]

--- a/schema/application.hcl
+++ b/schema/application.hcl
@@ -49,6 +49,9 @@ table "applications" {
   primary_key {
     columns = [column.id]
   }
+  index "applications_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "applications_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]

--- a/schema/artifacts.hcl
+++ b/schema/artifacts.hcl
@@ -87,4 +87,10 @@ table "artifacts" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "artifacts_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "artifacts_playbook_run_action_id_idx" {
+    columns = [column.playbook_run_action_id]
+  }
 }

--- a/schema/checks.hcl
+++ b/schema/checks.hcl
@@ -84,6 +84,12 @@ table "canaries" {
   index "canaries_source_idx" {
     columns = [column.source]
   }
+  index "canaries_agent_id_idx" {
+    columns = [column.agent_id]
+  }
+  index "canaries_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 table "check_statuses" {

--- a/schema/components.hcl
+++ b/schema/components.hcl
@@ -82,6 +82,12 @@ table "topologies" {
     columns = [column.is_pushed]
     where   = "is_pushed IS FALSE"
   }
+  index "topologies_agent_id_idx" {
+    columns = [column.agent_id]
+  }
+  index "topologies_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 
@@ -146,6 +152,9 @@ table "component_relationships" {
   }
   index "idx_component_relationships_deleted_at" {
     columns = [column.deleted_at]
+  }
+  index "component_relationships_relationship_id_idx" {
+    columns = [column.relationship_id]
   }
 }
 
@@ -389,6 +398,9 @@ table "components" {
   index "idx_components_configs" {
     columns = [column.configs]
   }
+  index "components_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 table "check_component_relationships" {
@@ -457,7 +469,12 @@ table "check_component_relationships" {
   index "idx_check_component_relationships_deleted_at" {
     columns = [column.deleted_at]
   }
-
+  index "check_component_relationships_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "check_component_relationships_canary_id_idx" {
+    columns = [column.canary_id]
+  }
 }
 
 table "config_component_relationships" {
@@ -515,5 +532,8 @@ table "config_component_relationships" {
   index "config_component_relationships_is_pushed_idx" {
     columns = [column.is_pushed]
     where   = "is_pushed IS FALSE"
+  }
+  index "config_component_relationships_config_id_idx" {
+    columns = [column.config_id]
   }
 }

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -99,6 +99,9 @@ table "config_analysis" {
   index "config_analysis_scraper_id_idx" {
     columns = [column.scraper_id]
   }
+  index "config_analysis_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 table "config_changes" {
@@ -528,6 +531,9 @@ table "config_relationships" {
     columns = [column.is_pushed]
     where   = "is_pushed IS FALSE"
   }
+  index "config_relationships_config_id_idx" {
+    columns = [column.config_id]
+  }
 }
 
 table "check_config_relationships" {
@@ -592,6 +598,12 @@ table "check_config_relationships" {
   index "check_config_relationships_is_pushed_idx" {
     columns = [column.is_pushed]
     where   = "is_pushed IS FALSE"
+  }
+  index "check_config_relationships_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "check_config_relationships_canary_id_idx" {
+    columns = [column.canary_id]
   }
 }
 
@@ -678,6 +690,15 @@ table "config_scrapers" {
     columns = [column.is_pushed]
     where   = "is_pushed IS FALSE"
   }
+  index "config_scrapers_application_id_idx" {
+    columns = [column.application_id]
+  }
+  index "config_scrapers_agent_id_idx" {
+    columns = [column.agent_id]
+  }
+  index "config_scrapers_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 table "scrape_plugins" {
@@ -722,6 +743,9 @@ table "scrape_plugins" {
   }
   primary_key {
     columns = [column.id]
+  }
+  index "scrape_plugins_created_by_idx" {
+    columns = [column.created_by]
   }
   foreign_key "config_scraper_plugins_created_by_fkey" {
     columns     = [column.created_by]

--- a/schema/config_access.hcl
+++ b/schema/config_access.hcl
@@ -56,6 +56,9 @@ table "external_users" {
     columns = [column.aliases]
     where   = "deleted_at IS NULL"
   }
+  index "external_users_scraper_id_idx" {
+    columns = [column.scraper_id]
+  }
 }
 
 table "external_groups" {
@@ -108,6 +111,9 @@ table "external_groups" {
     columns = [column.aliases]
     where   = "deleted_at IS NULL"
   }
+  index "external_groups_scraper_id_idx" {
+    columns = [column.scraper_id]
+  }
 }
 
 table "external_user_groups" {
@@ -145,6 +151,9 @@ table "external_user_groups" {
     columns     = [column.external_group_id]
     ref_columns = [table.external_groups.column.id]
     on_delete   = NO_ACTION
+  }
+  index "external_user_groups_external_group_id_idx" {
+    columns = [column.external_group_id]
   }
 }
 
@@ -208,10 +217,22 @@ table "external_roles" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  foreign_key "external_roles_scraper_id_fkey" {
+    columns     = [column.scraper_id]
+    ref_columns = [table.config_scrapers.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
   index "external_roles_aliases_key" {
     unique  = true
     columns = [column.aliases]
     where   = "deleted_at IS NULL"
+  }
+  index "external_roles_application_id_idx" {
+    columns = [column.application_id]
+  }
+  index "external_roles_scraper_id_idx" {
+    columns = [column.scraper_id]
   }
 }
 
@@ -270,6 +291,18 @@ table "access_reviews" {
     ref_columns = [table.config_scrapers.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "access_reviews_config_id_idx" {
+    columns = [column.config_id]
+  }
+  index "access_reviews_external_user_id_idx" {
+    columns = [column.external_user_id]
+  }
+  index "access_reviews_external_role_id_idx" {
+    columns = [column.external_role_id]
+  }
+  index "access_reviews_scraper_id_idx" {
+    columns = [column.scraper_id]
   }
 }
 
@@ -378,6 +411,21 @@ table "config_access" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "config_access_external_user_id_idx" {
+    columns = [column.external_user_id]
+  }
+  index "config_access_external_group_id_idx" {
+    columns = [column.external_group_id]
+  }
+  index "config_access_external_role_id_idx" {
+    columns = [column.external_role_id]
+  }
+  index "config_access_scraper_id_idx" {
+    columns = [column.scraper_id]
+  }
+  index "config_access_application_id_idx" {
+    columns = [column.application_id]
+  }
   check "config_access_origin" {
     expr    = "scraper_id IS NOT NULL OR application_id IS NOT NULL OR source IS NOT NULL"
     comment = "Every config_access row must be owned by a scraper, an application, or an internal source"
@@ -430,5 +478,11 @@ table "config_access_logs" {
     ref_columns = [table.config_scrapers.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "config_access_logs_external_user_id_idx" {
+    columns = [column.external_user_id]
+  }
+  index "config_access_logs_scraper_id_idx" {
+    columns = [column.scraper_id]
   }
 }

--- a/schema/connections.hcl
+++ b/schema/connections.hcl
@@ -79,6 +79,9 @@ table "connections" {
     columns = [column.name, column.namespace]
     where   = "deleted_at IS NULL"
   }
+  index "connections_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "connections_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]

--- a/schema/incidents.hcl
+++ b/schema/incidents.hcl
@@ -129,6 +129,27 @@ table "evidences" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "evidences_hypothesis_id_idx" {
+    columns = [column.hypothesis_id]
+  }
+  index "evidences_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "evidences_component_id_idx" {
+    columns = [column.component_id]
+  }
+  index "evidences_config_analysis_id_idx" {
+    columns = [column.config_analysis_id]
+  }
+  index "evidences_config_change_id_idx" {
+    columns = [column.config_change_id]
+  }
+  index "evidences_config_id_idx" {
+    columns = [column.config_id]
+  }
+  index "evidences_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 table "hypotheses" {
   schema = schema.public
@@ -214,6 +235,21 @@ table "hypotheses" {
   }
   check "hypotheses_type_check" {
     expr = "(type = ANY (ARRAY['root'::text, 'factor'::text, 'solution'::text]))"
+  }
+  index "hypotheses_incident_id_idx" {
+    columns = [column.incident_id]
+  }
+  index "hypotheses_parent_id_idx" {
+    columns = [column.parent_id]
+  }
+  index "hypotheses_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "hypotheses_owner_idx" {
+    columns = [column.owner]
+  }
+  index "hypotheses_team_id_idx" {
+    columns = [column.team_id]
   }
 }
 
@@ -305,6 +341,24 @@ table "incident_histories" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "incident_histories_incident_id_idx" {
+    columns = [column.incident_id]
+  }
+  index "incident_histories_comment_id_idx" {
+    columns = [column.comment_id]
+  }
+  index "incident_histories_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "incident_histories_evidence_id_idx" {
+    columns = [column.evidence_id]
+  }
+  index "incident_histories_hypothesis_id_idx" {
+    columns = [column.hypothesis_id]
+  }
+  index "incident_histories_responder_id_idx" {
+    columns = [column.responder_id]
+  }
 }
 
 table "incident_relationships" {
@@ -342,6 +396,12 @@ table "incident_relationships" {
     ref_columns = [table.incidents.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "incident_relationships_incident_id_idx" {
+    columns = [column.incident_id]
+  }
+  index "incident_relationships_related_id_idx" {
+    columns = [column.related_id]
   }
 }
 table "incident_rules" {
@@ -393,6 +453,9 @@ table "incident_rules" {
   index "incident_rules_name_key" {
     unique  = true
     columns = [column.name]
+  }
+  index "incident_rules_created_by_idx" {
+    columns = [column.created_by]
   }
 }
 
@@ -472,6 +535,18 @@ table "incidents" {
   index "incidents_incident_id_key" {
     unique  = true
     columns = [column.incident_id]
+  }
+  index "incidents_commander_id_idx" {
+    columns = [column.commander_id]
+  }
+  index "incidents_communicator_id_idx" {
+    columns = [column.communicator_id]
+  }
+  index "incidents_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "incidents_incident_rule_id_idx" {
+    columns = [column.incident_rule_id]
   }
   foreign_key "incidents_commander_id_fkey" {
     columns     = [column.commander_id]
@@ -591,9 +666,19 @@ table "responders" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "responders_incident_id_idx" {
+    columns = [column.incident_id]
+  }
+  index "responders_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "responders_person_id_idx" {
+    columns = [column.person_id]
+  }
+  index "responders_team_id_idx" {
+    columns = [column.team_id]
+  }
 }
-
-
 
 table "comment_responders" {
   schema = schema.public
@@ -638,6 +723,12 @@ table "comment_responders" {
     ref_columns = [table.responders.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "comment_responders_comment_id_idx" {
+    columns = [column.comment_id]
+  }
+  index "comment_responders_responder_id_idx" {
+    columns = [column.responder_id]
   }
 }
 table "comments" {
@@ -715,6 +806,18 @@ table "comments" {
     ref_columns = [table.responders.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "comments_incident_id_idx" {
+    columns = [column.incident_id]
+  }
+  index "comments_hypothesis_id_idx" {
+    columns = [column.hypothesis_id]
+  }
+  index "comments_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "comments_responder_id_idx" {
+    columns = [column.responder_id]
   }
 }
 

--- a/schema/logging_backends.hcl
+++ b/schema/logging_backends.hcl
@@ -45,9 +45,21 @@ table "logging_backends" {
   primary_key {
     columns = [column.id]
   }
+  index "logging_backends_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "logging_backends_agent_id_idx" {
+    columns = [column.agent_id]
+  }
   foreign_key "logging_backends_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  foreign_key "logging_backends_agent_id_fkey" {
+    columns     = [column.agent_id]
+    ref_columns = [table.agents.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }

--- a/schema/notifications.hcl
+++ b/schema/notifications.hcl
@@ -167,6 +167,15 @@ table "notifications" {
     columns = [column.name, column.namespace]
     where   = "deleted_at IS NULL"
   }
+  index "notifications_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "notifications_person_id_idx" {
+    columns = [column.person_id]
+  }
+  index "notifications_team_id_idx" {
+    columns = [column.team_id]
+  }
 }
 
 table "notification_send_history" {
@@ -312,6 +321,18 @@ table "notification_send_history" {
     on_update   = CASCADE
     on_delete   = CASCADE
   }
+  index "notification_send_history_notification_id_idx" {
+    columns = [column.notification_id]
+  }
+  index "notification_send_history_parent_id_idx" {
+    columns = [column.parent_id]
+  }
+  index "notification_send_history_person_id_idx" {
+    columns = [column.person_id]
+  }
+  index "notification_send_history_resource_id_idx" {
+    columns = [column.resource_id]
+  }
 }
 
 table "notification_silences" {
@@ -438,6 +459,21 @@ table "notification_silences" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
+  index "notification_silences_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "notification_silences_config_id_idx" {
+    columns = [column.config_id]
+  }
+  index "notification_silences_component_id_idx" {
+    columns = [column.component_id]
+  }
+  index "notification_silences_canary_id_idx" {
+    columns = [column.canary_id]
+  }
+  index "notification_silences_created_by_idx" {
+    columns = [column.created_by]
+  }
 }
 
 table "notification_groups" {
@@ -468,6 +504,12 @@ table "notification_groups" {
     ref_columns = [table.notifications.column.id]
     on_update   = CASCADE
     on_delete   = CASCADE
+  }
+  index "notification_groups_notification_id_idx" {
+    columns = [column.notification_id]
+  }
+  index "notification_groups_hash_notification_id_idx" {
+    columns = [column.hash, column.notification_id]
   }
 }
 
@@ -526,5 +568,17 @@ table "notification_group_resources" {
     ref_columns = [table.components.column.id]
     on_update   = CASCADE
     on_delete   = CASCADE
+  }
+  index "notification_group_resources_group_id_idx" {
+    columns = [column.group_id]
+  }
+  index "notification_group_resources_config_id_idx" {
+    columns = [column.config_id]
+  }
+  index "notification_group_resources_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "notification_group_resources_component_id_idx" {
+    columns = [column.component_id]
   }
 }

--- a/schema/permissions.hcl
+++ b/schema/permissions.hcl
@@ -227,9 +227,29 @@ table "permissions" {
   index "permissions_config_id_idx" {
     columns = [column.config_id]
   }
-
   index "permissions_component_id_idx" {
     columns = [column.component_id]
+  }
+  index "permissions_canary_id_idx" {
+    columns = [column.canary_id]
+  }
+  index "permissions_playbook_id_idx" {
+    columns = [column.playbook_id]
+  }
+  index "permissions_connection_id_idx" {
+    columns = [column.connection_id]
+  }
+  index "permissions_person_id_idx" {
+    columns = [column.person_id]
+  }
+  index "permissions_team_id_idx" {
+    columns = [column.team_id]
+  }
+  index "permissions_notification_id_idx" {
+    columns = [column.notification_id]
+  }
+  index "permissions_created_by_idx" {
+    columns = [column.created_by]
   }
 }
 
@@ -294,6 +314,10 @@ table "permission_groups" {
     unique  = true
     columns = [column.namespace, column.name]
     where   = "deleted_at IS NULL"
+  }
+
+  index "permission_groups_created_by_idx" {
+    columns = [column.created_by]
   }
 
   foreign_key "permissions_created_by_fkey" {

--- a/schema/playbooks.hcl
+++ b/schema/playbooks.hcl
@@ -66,6 +66,9 @@ table "playbooks" {
     columns = [column.namespace, column.name, column.category]
     where   = "deleted_at IS NULL"
   }
+  index "playbooks_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "playbook_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
@@ -115,6 +118,15 @@ table "playbook_approvals" {
     ref_columns = [table.teams.column.id]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
+  }
+  index "playbook_approvals_run_id_idx" {
+    columns = [column.run_id]
+  }
+  index "playbook_approvals_person_id_idx" {
+    columns = [column.person_id]
+  }
+  index "playbook_approvals_team_id_idx" {
+    columns = [column.team_id]
   }
   comment = "Keeps track of approvals on a playbook run"
 }
@@ -268,6 +280,30 @@ table "playbook_runs" {
   index "idx_playbook_runs_parent_id" {
     columns = [column.parent_id]
   }
+  index "playbook_runs_playbook_id_idx" {
+    columns = [column.playbook_id]
+  }
+  index "playbook_runs_check_id_idx" {
+    columns = [column.check_id]
+  }
+  index "playbook_runs_config_id_idx" {
+    columns = [column.config_id]
+  }
+  index "playbook_runs_component_id_idx" {
+    columns = [column.component_id]
+  }
+  index "playbook_runs_agent_id_idx" {
+    columns = [column.agent_id]
+  }
+  index "playbook_runs_notification_send_id_idx" {
+    columns = [column.notification_send_id]
+  }
+  index "playbook_runs_created_by_idx" {
+    columns = [column.created_by]
+  }
+  index "playbook_runs_status_scheduled_time_idx" {
+    columns = [column.status, column.scheduled_time]
+  }
 }
 
 table "playbook_action_agent_data" {
@@ -302,6 +338,10 @@ table "playbook_action_agent_data" {
     ref_columns = [table.playbook_run_actions.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  index "playbook_action_agent_data_action_id_idx" {
+    unique  = true
+    columns = [column.action_id]
   }
 }
 
@@ -384,5 +424,8 @@ table "playbook_run_actions" {
   }
   index "playbook_run_actions_playbook_run_id_idx" {
     columns = [column.playbook_run_id]
+  }
+  index "playbook_run_actions_agent_id_idx" {
+    columns = [column.agent_id]
   }
 }

--- a/schema/properties.hcl
+++ b/schema/properties.hcl
@@ -29,6 +29,9 @@ table "properties" {
   primary_key {
     columns = [column.name]
   }
+  index "properties_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "properties_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]

--- a/schema/scopes.hcl
+++ b/schema/scopes.hcl
@@ -70,6 +70,10 @@ table "scopes" {
     where   = "deleted_at IS NULL"
   }
 
+  index "scopes_created_by_idx" {
+    columns = [column.created_by]
+  }
+
   foreign_key "scopes_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]

--- a/schema/system.hcl
+++ b/schema/system.hcl
@@ -44,6 +44,9 @@ table "access_tokens" {
   index "access_tokens_value_idx" {
     columns = [column.value]
   }
+  index "access_tokens_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "access_tokens_person_fkey" {
     columns     = [column.person_id]
     ref_columns = [table.people.column.id]
@@ -156,6 +159,9 @@ table "integrations" {
   }
   primary_key {
     columns = [column.id]
+  }
+  index "integrations_created_by_idx" {
+    columns = [column.created_by]
   }
   foreign_key "integrations_created_by_fkey" {
     columns     = [column.created_by]

--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -76,6 +76,9 @@ table "people" {
   index "people_external_id_idx" {
     columns = [column.external_id]
   }
+  index "people_team_id_idx" {
+    columns = [column.team_id]
+  }
   foreign_key "people_team_id_fkey" {
     columns     = [column.team_id]
     ref_columns = [table.teams.column.id]
@@ -113,6 +116,9 @@ table "team_members" {
     ref_columns = [table.teams.column.id]
     on_update   = CASCADE
     on_delete   = CASCADE
+  }
+  index "team_members_person_id_idx" {
+    columns = [column.person_id]
   }
 }
 
@@ -165,6 +171,9 @@ table "teams" {
     columns = [column.name]
     where   = "deleted_at IS NULL"
   }
+  index "teams_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "teams_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
@@ -209,6 +218,9 @@ table "team_components" {
   index "team_components_team_id_component_id_selector_id_key" {
     unique  = true
     columns = [column.team_id, column.component_id, column.selector_id]
+  }
+  index "team_components_component_id_idx" {
+    columns = [column.component_id]
   }
 }
 

--- a/schema/views.hcl
+++ b/schema/views.hcl
@@ -55,6 +55,9 @@ table "views" {
   primary_key {
     columns = [column.id]
   }
+  index "views_created_by_idx" {
+    columns = [column.created_by]
+  }
   foreign_key "views_created_by_fkey" {
     columns     = [column.created_by]
     ref_columns = [table.people.column.id]
@@ -105,6 +108,9 @@ table "view_panels" {
   primary_key {
     columns = [column.view_id, column.request_fingerprint]
     comment = "one record per view per request fingerprint"
+  }
+  index "view_panels_agent_id_idx" {
+    columns = [column.agent_id]
   }
   index "idx_view_panels_request_fingerprint" {
     columns = [column.view_id, column.request_fingerprint]


### PR DESCRIPTION
Add 74 missing indexes on foreign key columns across all schema files.
PostgreSQL does not auto-create indexes for FK columns, causing full
sequential scans on joins, cascade deletes, and filtered queries.

Also add two missing FK constraints:
- logging_backends.agent_id -> agents.id
- external_roles.scraper_id -> config_scrapers.id

Agent Conversation: https://pi.dev/session/#23fc14d97915172bb47a9799228d080b
