### PR TITLE
chore: add count column in config access logs

### DIFF
--- a/models/config_access.go
+++ b/models/config_access.go
@@ -217,6 +217,7 @@ type ConfigAccessLog struct {
 	CreatedAt      time.Time     `json:"created_at"`
 	MFA            bool          `json:"mfa,omitempty" gorm:"default:null"`
 	Properties     types.JSONMap `json:"properties,omitempty" gorm:"default:null"`
+	Count          *int          `json:"count,omitempty" gorm:"default:1"`
 }
 
 func (e ConfigAccessLog) TableName() string {

--- a/schema/config_access.hcl
+++ b/schema/config_access.hcl
@@ -457,6 +457,10 @@ table "config_access_logs" {
     type = jsonb
     null = true
   }
+  column "count" {
+    type    = integer
+    default = 1
+  }
   column "created_at" {
     type = timestamptz
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Config access logs now track an access count for each log entry, defaulting to 1, enabling improved visibility into access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->