### PR TITLE
refactor(shell): unexport internal symbols and remove RunCmd

### DIFF
--- a/shell/common.go
+++ b/shell/common.go
@@ -15,9 +15,10 @@ func JQ(ctx context.Context, path string, script string) (string, error) {
 	defer cancel()
 
 	cmd := osExec.CommandContext(_ctx, "jq", script, path)
-	result, err := RunCmd(ctx, Exec{
-		Chroot: path,
-	}, cmd)
+	cmd.Env = getEnvVar(nil)
+	result, err := runCmd(ctx, &commandContext{
+		cmd: cmd,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -29,9 +30,10 @@ func YQ(ctx context.Context, path string, script string) (string, error) {
 	defer cancel()
 
 	cmd := osExec.CommandContext(_ctx, "yq", script, path)
-	result, err := RunCmd(ctx, Exec{
-		Chroot: path,
-	}, cmd)
+	cmd.Env = getEnvVar(nil)
+	result, err := runCmd(ctx, &commandContext{
+		cmd: cmd,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/shell/interpreter.go
+++ b/shell/interpreter.go
@@ -14,18 +14,18 @@ import (
 	"github.com/flanksource/duty/context"
 )
 
-var DefaultInterpreter string
-var DefaultInterpreterArgs []string
+var defaultInterpreter string
+var defaultInterpreterArgs []string
 
 func init() {
-	DefaultInterpreter, DefaultInterpreterArgs = DetectDefaultInterpreter()
+	defaultInterpreter, defaultInterpreterArgs = detectDefaultInterpreter()
 }
 
-// CreateCommandFromScript creates an os/exec.Cmd from the script, using the interpreter specified in the shebang line if present.
-func CreateCommandFromScript(ctx context.Context, script string, envs []string, setup *ExecSetup, runID string) (*exec.Cmd, error) {
-	shebangInterpreter, _ := DetectInterpreterFromShebang(script)
+// createCommandFromScript creates an os/exec.Cmd from the script, using the interpreter specified in the shebang line if present.
+func createCommandFromScript(ctx context.Context, script string, envs []string, setup *ExecSetup, runID string) (*exec.Cmd, error) {
+	shebangInterpreter, _ := detectInterpreterFromShebang(script)
 	interpreter, args := remapInterpreter(script, setup)
-	script = TrimLine(script, "#!")
+	script = trimLine(script, "#!")
 	if script == "" {
 		return nil, ctx.Oops().Errorf("empty script")
 	}
@@ -60,7 +60,7 @@ func CreateCommandFromScript(ctx context.Context, script string, envs []string, 
 	return cmd, nil
 }
 
-func TrimLine(lines string, prefix string) string {
+func trimLine(lines string, prefix string) string {
 	s := []string{}
 	for _, line := range strings.Split(lines, "\n") {
 		if !strings.HasPrefix(line, prefix) {
@@ -70,8 +70,8 @@ func TrimLine(lines string, prefix string) string {
 	return strings.Join(s, "\n")
 }
 
-// DetectInterpreterFromShebang reads the first line of the script to detect the interpreter from the shebang line.
-func DetectInterpreterFromShebang(script string) (string, []string) {
+// detectInterpreterFromShebang reads the first line of the script to detect the interpreter from the shebang line.
+func detectInterpreterFromShebang(script string) (string, []string) {
 	reader := strings.NewReader(script)
 	scanner := bufio.NewScanner(reader)
 	if scanner.Scan() {
@@ -109,7 +109,7 @@ func DetectInterpreterFromShebang(script string) (string, []string) {
 					args = append(args, "-e")
 				}
 			case "pwsh", "powershell":
-				// PowerShell uses -File for script files, handled separately in CreateCommandFromScript
+				// PowerShell uses -File for script files, handled separately in createCommandFromScript
 			default:
 				if len(args) == 0 {
 					// No args, just interpreter and assume it supports the -c flag
@@ -120,11 +120,11 @@ func DetectInterpreterFromShebang(script string) (string, []string) {
 			return interpreter, args
 		}
 	}
-	return DefaultInterpreter, DefaultInterpreterArgs
+	return defaultInterpreter, defaultInterpreterArgs
 }
 
 func remapInterpreter(script string, setup *ExecSetup) (string, []string) {
-	interpreter, args := DetectInterpreterFromShebang(script)
+	interpreter, args := detectInterpreterFromShebang(script)
 	if !isPythonBase(interpreter) {
 		return interpreter, args
 	}
@@ -154,8 +154,8 @@ func isPowershellBase(interpreter string) bool {
 	return base == "pwsh" || base == "powershell"
 }
 
-// DetectDefaultInterpreter detects the default interpreter based on the OS.
-func DetectDefaultInterpreter() (string, []string) {
+// detectDefaultInterpreter detects the default interpreter based on the OS.
+func detectDefaultInterpreter() (string, []string) {
 	switch runtime.GOOS {
 	case "windows":
 		// Check for PowerShell on Windows

--- a/shell/testdata/data.json
+++ b/shell/testdata/data.json
@@ -1,0 +1,12 @@
+{
+  "name": "mission-control",
+  "version": "1.2.3",
+  "components": [
+    {"id": "db", "status": "healthy"},
+    {"id": "api", "status": "unhealthy"}
+  ],
+  "metadata": {
+    "region": "us-east-1",
+    "env": "production"
+  }
+}


### PR DESCRIPTION
Remove RunCmd from the public API. JQ/YQ helpers now call the
internal runCmd directly.

Unexport symbols only used within the package

Before:
```go
var DefaultInterpreter string
var DefaultInterpreterArgs []string
func CreateCommandFromScript(ctx context.Context, script string, envs []string, setup *ExecSetup, ...) (*exec.Cmd, error)
func DetectDefaultInterpreter() (string, []string)
func DetectInterpreterFromShebang(script string) (string, []string)
func JQ(ctx context.Context, path string, script string) (string, error)
func TrimLine(lines string, prefix string) string
func YQ(ctx context.Context, path string, script string) (string, error)
type Artifact struct{ ... }
type Exec struct{ ... }
type ExecDetails struct{ ... }
    func Run(ctx context.Context, exec Exec) (*ExecDetails, error)
    func RunCmd(ctx context.Context, exec Exec, cmd *osExec.Cmd) (*ExecDetails, error)
type ExecSetup struct{ ... }
type RuntimeSetup struct{ ... }

```

After:
```go
func JQ(ctx context.Context, path string, script string) (string, error)
func YQ(ctx context.Context, path string, script string) (string, error)
type Artifact struct{ ... }
type Exec struct{ ... }
type ExecDetails struct{ ... }
    func Run(ctx context.Context, exec Exec) (*ExecDetails, error)
type ExecSetup struct{ ... }
type RuntimeSetup struct{ ... }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal command execution and interpreter detection were reorganized for maintainability.
  * Removed an unused dependency.

* **Breaking Changes**
  * One public command-execution API was removed; callers must switch to the new execution approach.

* **Tests**
  * Added new unit tests covering command processing and a sample test data file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->