### PR TITLE
fix: allow empty connection type in HTTP hydration

### DIFF
--- a/connection/http.go
+++ b/connection/http.go
@@ -452,7 +452,7 @@ func CreateHTTPClient(ctx ConnectionContext, conn HTTPConnection) (*http.Client,
 func NewHTTPConnection(ctx ConnectionContext, conn models.Connection) (HTTPConnection, error) {
 	var httpConn HTTPConnection
 	switch conn.Type {
-	case models.ConnectionTypeHTTP, models.ConnectionTypePrometheus:
+	case models.ConnectionTypeHTTP, models.ConnectionTypePrometheus, "":
 		if err := httpConn.FromModel(conn); err != nil {
 			return httpConn, err
 		}


### PR DESCRIPTION
## Summary
- Connections created with the deprecated `spec.url` field (no typed spec like `spec.http`) have an empty `Type` in the database
- `NewHTTPConnection` rejected these with `"invalid connection type: "` because the switch had no case for `""`
- Add `""` to the HTTP/Prometheus case so legacy URL-only connections hydrate correctly

## Test plan
- Playbook connection permission tests in incident-commander pass with this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP connection handling to properly recognize empty connection strings as valid connection types alongside standard configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->