### PR TITLE
feat(rbac): add ABACObjectSelector for ABAC companion rule generation

### DIFF
--- a/rbac/policy/policy.go
+++ b/rbac/policy/policy.go
@@ -298,3 +298,39 @@ var AllObjects = []string{
 	ObjectNotification,
 	ObjectViews,
 }
+
+// ABACObjectSelector returns the ABAC object selector JSON for a given
+// global RBAC object and action combination. This is used to generate
+// companion ABAC wildcard rules so that both default policies and
+// Permission-derived policies work with HasPermission() ABAC checks.
+// Returns nil if no ABAC companion rule is needed for the given object/action.
+func ABACObjectSelector(object, action string) []byte {
+	switch object {
+	case ObjectPlaybooks:
+		if lo.Contains([]string{ActionPlaybookRun, ActionPlaybookApprove}, action) {
+			return []byte(`{"playbooks": [{"name":"*"}]}`)
+		}
+
+	case ObjectCatalog:
+		if ActionRead == action {
+			return []byte(`{"configs": [{"name":"*"}]}`)
+		}
+
+	case ObjectTopology:
+		if ActionRead == action {
+			return []byte(`{"components": [{"name":"*"}]}`)
+		}
+
+	case ObjectConnection:
+		if ActionRead == action {
+			return []byte(`{"connections": [{"name":"*"}]}`)
+		}
+
+	case ObjectViews:
+		if ActionRead == action {
+			return []byte(`{"views": [{"name":"*"}]}`)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Extract the object+action → ABAC selector mapping into a shared `ABACObjectSelector` function in the policy package.

Default policies from `policies.yaml` (e.g. `viewer, views, read`) only generate plain RBAC rules with string objects. These don't match `HasPermission()` ABAC checks where `r.obj` is `*ABACAttribute`. This function allows callers (e.g. mission-control's `PermissionAdapter`) to generate in-memory ABAC wildcard companion rules on each policy reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced access control handling for specific resource types including playbooks, catalogs, topologies, connections, and views to support more granular permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->