### PR TITLE
fix(db): enforce element-level uniqueness on text[] fields

### DIFF
--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -403,6 +403,7 @@ table "config_items" {
   index "idx_config_items_external_id" {
     columns = [column.external_id]
     type    = GIN
+    where   = "deleted_at IS NULL"
   }
   index "idx_config_items_deleted_at" {
     columns = [column.deleted_at]

--- a/schema/config_access.hcl
+++ b/schema/config_access.hcl
@@ -51,9 +51,9 @@ table "external_users" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  index "external_users_aliases_key" {
-    unique  = true
+  index "external_users_aliases_idx" {
     columns = [column.aliases]
+    type    = GIN
     where   = "deleted_at IS NULL"
   }
   index "external_users_scraper_id_idx" {
@@ -106,9 +106,9 @@ table "external_groups" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  index "external_groups_aliases_key" {
-    unique  = true
+  index "external_groups_aliases_idx" {
     columns = [column.aliases]
+    type    = GIN
     where   = "deleted_at IS NULL"
   }
   index "external_groups_scraper_id_idx" {
@@ -223,9 +223,9 @@ table "external_roles" {
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }
-  index "external_roles_aliases_key" {
-    unique  = true
+  index "external_roles_aliases_idx" {
     columns = [column.aliases]
+    type    = GIN
     where   = "deleted_at IS NULL"
   }
   index "external_roles_application_id_idx" {

--- a/tests/config_access_test.go
+++ b/tests/config_access_test.go
@@ -146,6 +146,28 @@ var _ = Describe("External Users Aliases", Ordered, func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should enforce element-level uniqueness across aliases", func() {
+		sharedAlias := "user-overlap-" + uuid.NewString()
+
+		user1 := models.ExternalUser{
+			ID:        uuid.New(),
+			Name:      "Test Overlap User 1",
+			ScraperID: scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "user-unique-" + uuid.NewString()},
+		}
+		err := DefaultContext.DB().Create(&user1).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		user2 := models.ExternalUser{
+			ID:        uuid.New(),
+			Name:      "Test Overlap User 2",
+			ScraperID: scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "user-unique-" + uuid.NewString()},
+		}
+		err = DefaultContext.DB().Create(&user2).Error
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should enforce unique constraint case-insensitively", func() {
 		user1 := models.ExternalUser{
 			ID:        uuid.New(),
@@ -258,6 +280,28 @@ var _ = Describe("External Roles Aliases", Ordered, func() {
 			Name:      "Test Role Unique 2",
 			ScraperID: &scraperID,
 			Aliases:   aliases,
+		}
+		err = DefaultContext.DB().Create(&role2).Error
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should enforce element-level uniqueness across aliases", func() {
+		sharedAlias := "role-overlap-" + uuid.NewString()
+
+		role1 := models.ExternalRole{
+			ID:        uuid.New(),
+			Name:      "Test Role Overlap 1",
+			ScraperID: &scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "role-unique-" + uuid.NewString()},
+		}
+		err := DefaultContext.DB().Create(&role1).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		role2 := models.ExternalRole{
+			ID:        uuid.New(),
+			Name:      "Test Role Overlap 2",
+			ScraperID: &scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "role-unique-" + uuid.NewString()},
 		}
 		err = DefaultContext.DB().Create(&role2).Error
 		Expect(err).To(HaveOccurred())
@@ -380,6 +424,28 @@ var _ = Describe("External Groups Aliases", Ordered, func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should enforce element-level uniqueness across aliases", func() {
+		sharedAlias := "group-overlap-" + uuid.NewString()
+
+		group1 := models.ExternalGroup{
+			ID:        uuid.New(),
+			Name:      "Test Group Overlap 1",
+			ScraperID: scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "group-unique-" + uuid.NewString()},
+		}
+		err := DefaultContext.DB().Create(&group1).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		group2 := models.ExternalGroup{
+			ID:        uuid.New(),
+			Name:      "Test Group Overlap 2",
+			ScraperID: scraperID,
+			Aliases:   pq.StringArray{sharedAlias, "group-unique-" + uuid.NewString()},
+		}
+		err = DefaultContext.DB().Create(&group2).Error
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should enforce unique constraint case-insensitively", func() {
 		group1 := models.ExternalGroup{
 			ID:        uuid.New(),
@@ -397,6 +463,40 @@ var _ = Describe("External Groups Aliases", Ordered, func() {
 			Aliases:   pq.StringArray{"groupcasetest1", "GROUPCASETEST2"},
 		}
 		err = DefaultContext.DB().Create(&group2).Error
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("Config Items External IDs", Ordered, func() {
+	It("should enforce element-level uniqueness across external_id", func() {
+		sharedExternalID := "config-overlap-" + uuid.NewString()
+		typeA := "Config::ExternalID::A"
+		typeB := "Config::ExternalID::B"
+
+		item1 := models.ConfigItem{
+			ID:          uuid.New(),
+			ConfigClass: models.ConfigClassNode,
+			Type:        &typeA,
+			ExternalID:  pq.StringArray{sharedExternalID, "config-unique-" + uuid.NewString()},
+		}
+
+		item2 := models.ConfigItem{
+			ID:          uuid.New(),
+			ConfigClass: models.ConfigClassNode,
+			Type:        &typeB,
+			ExternalID:  pq.StringArray{sharedExternalID, "config-unique-" + uuid.NewString()},
+		}
+
+		cleanupIDs := []uuid.UUID{item1.ID, item2.ID}
+		defer func() {
+			err := DefaultContext.DB().Unscoped().Where("id IN ?", cleanupIDs).Delete(&models.ConfigItem{}).Error
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		err := DefaultContext.DB().Create(&item1).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		err = DefaultContext.DB().Create(&item2).Error
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/tests/fixtures/dummy/config.go
+++ b/tests/fixtures/dummy/config.go
@@ -112,7 +112,7 @@ var KubernetesNodeA = models.ConfigItem{
 	ConfigClass: models.ConfigClassNode,
 	Config:      lo.ToPtr(`{"apiVersion":"v1", "kind":"Node", "metadata": {"name": "node-a"}}`),
 	Type:        lo.ToPtr("Kubernetes::Node"),
-	ExternalID:  pq.StringArray{"aws/us-east-1/clusters", "node://kubernetes/demo/node-a", "kubernetes/nodes"},
+	ExternalID:  pq.StringArray{"aws/us-east-1/clusters", "node://kubernetes/demo/node-a", "kubernetes/nodes/node-a"},
 	CreatedAt:   DummyCreatedAt.Add(time.Hour * 24),
 	Status:      lo.ToPtr("healthy"),
 	Tags: types.JSONStringMap{
@@ -140,7 +140,7 @@ var KubernetesNodeB = models.ConfigItem{
 	Config:      lo.ToPtr(`{"apiVersion":"v1", "kind":"Node", "metadata": {"name": "node-b"}}`),
 	ConfigClass: models.ConfigClassNode,
 	Type:        lo.ToPtr("Kubernetes::Node"),
-	ExternalID:  pq.StringArray{"aws/us-west-2/clusters", "node://kubernetes/node-b", "kubernetes/nodes"},
+	ExternalID:  pq.StringArray{"aws/us-west-2/clusters", "node://kubernetes/node-b", "kubernetes/nodes/node-b"},
 	CreatedAt:   DummyCreatedAt.Add(time.Hour * 24 * 2),
 	Status:      lo.ToPtr("healthy"),
 	Tags: types.JSONStringMap{

--- a/views/044_element_unique_arrays.sql
+++ b/views/044_element_unique_arrays.sql
@@ -1,0 +1,96 @@
+-- Enforce element-level uniqueness for selected text[] columns using
+-- deferrable constraint triggers + advisory locks.
+--
+-- Why this exists:
+-- - UNIQUE on text[] only checks whole-array equality.
+-- - PostgreSQL cannot do EXCLUDE USING GIN for && overlap checks.
+
+-- Drop and recreate triggers because constraint triggers do not support OR REPLACE.
+DROP TRIGGER IF EXISTS external_users_aliases_element_unique ON external_users;
+DROP TRIGGER IF EXISTS external_groups_aliases_element_unique ON external_groups;
+DROP TRIGGER IF EXISTS external_roles_aliases_element_unique ON external_roles;
+DROP TRIGGER IF EXISTS config_items_external_id_element_unique ON config_items;
+
+CREATE OR REPLACE FUNCTION check_array_no_overlap()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  col_name    text := TG_ARGV[0];
+  new_val     text[];
+  elem        text;
+  conflict_id uuid;
+BEGIN
+  EXECUTE format('SELECT ($1).%I', col_name) INTO new_val USING NEW;
+
+  -- Only enforce for active rows with non-empty arrays.
+  IF NEW.deleted_at IS NOT NULL OR COALESCE(cardinality(new_val), 0) = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- Serialize competing writers for each element to avoid races.
+  -- Sorted order prevents lock-order deadlocks.
+  FOR elem IN
+    SELECT DISTINCT e
+    FROM unnest(new_val) AS e
+    WHERE e IS NOT NULL
+    ORDER BY e
+  LOOP
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended(
+        format('%I.%I.%I:%s', TG_TABLE_SCHEMA, TG_TABLE_NAME, col_name, elem),
+        0
+      )
+    );
+  END LOOP;
+
+  -- Check if any active sibling row overlaps with the incoming array.
+  EXECUTE format(
+    'SELECT id
+       FROM %I.%I
+      WHERE deleted_at IS NULL
+        AND id <> $1
+        AND %I && $2
+      LIMIT 1',
+    TG_TABLE_SCHEMA, TG_TABLE_NAME, col_name
+  )
+  INTO conflict_id
+  USING NEW.id, new_val;
+
+  IF conflict_id IS NOT NULL THEN
+    RAISE EXCEPTION 'conflicting array element in column "%" of table "%"', col_name, TG_TABLE_NAME
+      USING ERRCODE = '23505',
+            DETAIL = format('id=%s conflicts with existing id=%s', NEW.id, conflict_id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- external_users.aliases element-level uniqueness
+CREATE CONSTRAINT TRIGGER external_users_aliases_element_unique
+AFTER INSERT OR UPDATE OF aliases, deleted_at ON external_users
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION check_array_no_overlap('aliases');
+
+-- external_groups.aliases element-level uniqueness
+CREATE CONSTRAINT TRIGGER external_groups_aliases_element_unique
+AFTER INSERT OR UPDATE OF aliases, deleted_at ON external_groups
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION check_array_no_overlap('aliases');
+
+-- external_roles.aliases element-level uniqueness
+CREATE CONSTRAINT TRIGGER external_roles_aliases_element_unique
+AFTER INSERT OR UPDATE OF aliases, deleted_at ON external_roles
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION check_array_no_overlap('aliases');
+
+-- config_items.external_id element-level uniqueness
+CREATE CONSTRAINT TRIGGER config_items_external_id_element_unique
+AFTER INSERT OR UPDATE OF external_id, deleted_at ON config_items
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION check_array_no_overlap('external_id');


### PR DESCRIPTION
- Enforce overlap-based uniqueness for external_users.aliases and config_items.external_id\n- Use deferrable constraint triggers with advisory locks for race-safe writes\n- Keep partial GIN indexes on active rows for overlap lookups\n- Update dummy fixture external IDs to satisfy global external_id uniqueness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented element-level uniqueness validation for aliases and external IDs to prevent duplicates across users, groups, and roles.

* **Performance**
  * Optimized database query performance for soft-deleted records through index improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->