### PR TITLE
chore: fix benchstat comparison and clean up workflow step names

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -72,8 +72,7 @@ jobs:
         run: |
           mkdir -p .bench
           git worktree add .bench/base "${{ github.event.pull_request.base.sha }}"
-          cp bench/bench_test.go .bench/base/bench/bench_test.go
-      - name: Build benchmark (base)
+      - name: Benchmark base
         run: |
           cd .bench/base
           DUTY_BENCH_SIZES="${BENCH_SIZES}" \
@@ -84,7 +83,7 @@ jobs:
           DUTY_BENCH_SIZES="${BENCH_SIZES}" \
             go test -bench=. -count=6 -timeout 15m \
             github.com/flanksource/duty/bench | tee bench-head.txt
-      - name: Compare
+      - name: Compare with benchstat
         run: |
           benchstat bench-base.txt bench-head.txt > benchstat.txt
           {


### PR DESCRIPTION
Remove bootstrap override that copied head's bench_test.go onto the
base worktree, preventing benchstat from producing a two-column
base vs head comparison.
