### PR TITLE
fix(rbac): generate ABAC companions for playbook read and additional actions

### DIFF
--- a/rbac/policy/policy.go
+++ b/rbac/policy/policy.go
@@ -271,10 +271,11 @@ const (
 
 var AllActions = []string{
 	ActionCreate,
-	ActionDelete,
 	ActionRead,
 	ActionUpdate,
+	ActionDelete,
 	ActionPlaybookApprove,
+	ActionPlaybookCancel,
 	ActionPlaybookRun,
 	ActionMCPRun,
 	ActionMCPUse,
@@ -317,7 +318,7 @@ var AllObjects = []string{
 func ABACObjectSelector(object, action string) []byte {
 	switch object {
 	case ObjectPlaybooks:
-		if lo.Contains([]string{ActionPlaybookRun, ActionPlaybookApprove}, action) {
+		if lo.Contains([]string{ActionPlaybookRun, ActionPlaybookApprove, ActionMCPRun, ActionMCPUse, ActionPlaybookCancel, ActionRead}, action) {
 			return []byte(`{"playbooks": [{"name":"*"}]}`)
 		}
 
@@ -337,7 +338,7 @@ func ABACObjectSelector(object, action string) []byte {
 		}
 
 	case ObjectViews:
-		if ActionRead == action {
+		if lo.Contains([]string{ActionMCPRun, ActionMCPUse, ActionRead}, action) {
 			return []byte(`{"views": [{"name":"*"}]}`)
 		}
 	}


### PR DESCRIPTION
Expand `ABACObjectSelector` to generate ABAC companion rules for:
- **playbooks**: `mcp:run`, `mcp:use`, `playbook:cancel`, `read`
- **views**: `mcp:run`, `mcp:use`

Without these companions, `HasPermission()` denies access even when the user has the correct RBAC role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playbook cancellation capability.

* **Refactor**
  * Enhanced overall access control and authorization framework for playbooks and views. Expanded authorization eligibility rules to now include support for MCP run and use operations, playbook cancellation, and read actions. Broadened view access conditions to provide more comprehensive permission coverage across various operation types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->