### PR TITLE
fix: set last_observed values where its NULL

### DIFF
--- a/functions/config_analysis_last_observed_fix.sql
+++ b/functions/config_analysis_last_observed_fix.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+  IF EXISTS (
+      SELECT 1
+      FROM pg_tables
+      WHERE schemaname = 'public'
+      AND tablename = 'config_analysis'
+  ) THEN
+      UPDATE config_analysis SET last_observed = NOW() WHERE last_observed IS NULL;
+  END IF;
+END $$;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a data consistency issue where observation timestamps were missing from certain records. The system now automatically populates missing timestamps with the current time during updates, ensuring accurate tracking and reporting of when records were last observed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->