### PR TITLE
fix(upstream): update config last scraped time id for agent

### DIFF
--- a/tests/fixtures/dummy/config.go
+++ b/tests/fixtures/dummy/config.go
@@ -331,8 +331,8 @@ var NginxIngressPodDeleted = models.ConfigItem{
 	Health:      lo.ToPtr(models.HealthHealthy),
 	Type:        lo.ToPtr("Kubernetes::Pod"),
 	Status:      lo.ToPtr("Running"),
-	CreatedAt:   time.Date(2021, 1, 1, 1, 1, 0, 0, time.UTC),
-	DeletedAt:   lo.ToPtr(time.Date(2021, 1, 1, 2, 1, 0, 0, time.UTC)),
+	CreatedAt:   CurrentTime.Add(-2 * time.Hour),
+	DeletedAt:   lo.ToPtr(CurrentTime.Add(-time.Hour)),
 	ParentID:    lo.ToPtr(NginxHelmRelease.ID),
 	ExternalID:  pq.StringArray{"kubernetes/ingress-nginx/pods"},
 	Config: lo.ToPtr(`{

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -354,6 +354,13 @@ func (t *PushData) AddAgentConfig(agent models.Agent) {
 		}
 	}
 
+	// Update agent's last scraped times with correct config ID
+	for i, ci := range t.ConfigItemsLastScrapedTime {
+		if ci.ConfigID == uuid.Nil {
+			t.ConfigItemsLastScrapedTime[i].ConfigID = agent.ID
+		}
+	}
+
 	// Filter out system scraper if present
 	t.ConfigScrapers = lo.Filter(t.ConfigScrapers, func(cs models.ConfigScraper, _ int) bool { return cs.ID != uuid.Nil })
 }

--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -1,0 +1,86 @@
+// ABOUTME: Tests for upstream push data transformations.
+// ABOUTME: Covers AddAgentConfig and related PushData methods.
+package upstream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+
+	"github.com/flanksource/duty/models"
+)
+
+func TestAddAgentConfig(t *testing.T) {
+	agentID := uuid.New()
+	agent := models.Agent{
+		ID:   agentID,
+		Name: "test-agent",
+	}
+
+	now := time.Now()
+
+	pushData := &PushData{
+		ConfigItems: []models.ConfigItem{
+			{
+				ID:   uuid.Nil,
+				Type: lo.ToPtr("MissionControl::ShouldBeFiltered"),
+			},
+			{
+				ID:   uuid.New(),
+				Type: lo.ToPtr("MissionControl::Agent"),
+			},
+		},
+		ConfigChanges: []models.ConfigChange{
+			{ConfigID: uuid.Nil.String()},
+		},
+		ConfigScrapers: []models.ConfigScraper{
+			{ID: uuid.Nil},
+			{ID: uuid.New()},
+		},
+		ConfigItemsLastScrapedTime: []models.ConfigItemLastScrapedTime{
+			{ConfigID: uuid.Nil, LastScrapedTime: &now},
+		},
+	}
+
+	pushData.AddAgentConfig(agent)
+
+	// Config item with uuid.Nil ID should be filtered out
+	if len(pushData.ConfigItems) != 1 {
+		t.Fatalf("expected 1 config item, got %d", len(pushData.ConfigItems))
+	}
+
+	// MissionControl::Agent item should have ID set to agent ID
+	ci := pushData.ConfigItems[0]
+	if ci.ID != agentID {
+		t.Errorf("expected agent config item ID to be %s, got %s", agentID, ci.ID)
+	}
+	if lo.FromPtr(ci.Name) != "test-agent" {
+		t.Errorf("expected agent config item name to be 'test-agent', got %s", lo.FromPtr(ci.Name))
+	}
+	if lo.FromPtr(ci.ScraperID) != uuid.Nil.String() {
+		t.Errorf("expected scraper_id to be nil UUID, got %s", lo.FromPtr(ci.ScraperID))
+	}
+
+	// Config changes with uuid.Nil config_id should be remapped
+	if pushData.ConfigChanges[0].ConfigID != agentID.String() {
+		t.Errorf("expected config change config_id to be %s, got %s", agentID, pushData.ConfigChanges[0].ConfigID)
+	}
+
+	// System scraper should be filtered out
+	if len(pushData.ConfigScrapers) != 1 {
+		t.Fatalf("expected 1 config scraper, got %d", len(pushData.ConfigScrapers))
+	}
+	if pushData.ConfigScrapers[0].ID == uuid.Nil {
+		t.Error("system scraper should have been filtered out")
+	}
+
+	// Last scraped time with uuid.Nil config_id should be remapped to agent ID
+	if len(pushData.ConfigItemsLastScrapedTime) != 1 {
+		t.Fatalf("expected 1 last scraped time entry, got %d", len(pushData.ConfigItemsLastScrapedTime))
+	}
+	if pushData.ConfigItemsLastScrapedTime[0].ConfigID != agentID {
+		t.Errorf("expected last scraped time config_id to be %s, got %s", agentID, pushData.ConfigItemsLastScrapedTime[0].ConfigID)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize configuration timestamps for agent setups to ensure accurate tracking of scraping activity across config items.

* **Tests**
  * Added test coverage for agent configuration handling and updated test fixtures to use relative timestamps for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->