### PR TITLE
chore(query): add support for timestamp in config changes

### DIFF
--- a/query/catalog_search.go
+++ b/query/catalog_search.go
@@ -60,10 +60,11 @@ func (b *BaseCatalogSearch) SetDefaults() {
 
 func (b *BaseCatalogSearch) Validate() error {
 	if b.From != "" && b.FromTime == nil {
-		expr, err := datemath.Parse(b.From)
-		if err != nil {
+		if parsed, err := time.Parse(time.RFC3339Nano, b.From); err == nil {
+			b.FromTime = &parsed
+		} else if expr, err := datemath.Parse(b.From); err != nil {
 			if !b.Lenient {
-				return fmt.Errorf("invalid 'from' param: %w", err)
+				return fmt.Errorf("invalid 'from' param: expected RFC3339 or datemath format: %w", err)
 			}
 			b.From = ""
 		} else {
@@ -72,10 +73,11 @@ func (b *BaseCatalogSearch) Validate() error {
 		}
 	}
 	if b.To != "" && b.ToTime == nil {
-		expr, err := datemath.Parse(b.To)
-		if err != nil {
+		if parsed, err := time.Parse(time.RFC3339Nano, b.To); err == nil {
+			b.ToTime = &parsed
+		} else if expr, err := datemath.Parse(b.To); err != nil {
 			if !b.Lenient {
-				return fmt.Errorf("invalid 'to' param: %w", err)
+				return fmt.Errorf("invalid 'to' param: expected RFC3339 or datemath format: %w", err)
 			}
 			b.To = ""
 		} else {
@@ -166,7 +168,7 @@ func (b *BaseCatalogSearch) ApplyClauses(excludeColumns ...string) ([]clause.Exp
 		}
 	}
 	if b.FromTime != nil && !excluded["created_at"] {
-		clauses = append(clauses, clause.Gte{Column: clause.Column{Name: "created_at"}, Value: *b.FromTime})
+		clauses = append(clauses, clause.Gt{Column: clause.Column{Name: "created_at"}, Value: *b.FromTime})
 	}
 	if b.ToTime != nil && !excluded["created_at"] {
 		clauses = append(clauses, clause.Lte{Column: clause.Column{Name: "created_at"}, Value: *b.ToTime})

--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -447,6 +447,48 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 			Expect(response.Total).To(BeNumerically(">=", 1))
 		})
 
+		ginkgo.Context("inserted_at filter", func() {
+			ginkgo.It("should accept RFC3339 with fractional seconds", func() {
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					BaseCatalogSearch: query.BaseCatalogSearch{
+						CatalogID: U.ID.String(),
+						Recursive: query.CatalogChangeRecursiveDownstream,
+					},
+					FromInsertedAt: "2026-03-09T09:02:00.76939Z",
+				})
+				Expect(err).To(BeNil())
+				Expect(response.Total).To(BeNumerically(">=", 1))
+
+				for _, c := range response.Changes {
+					Expect(c.InsertedAt).NotTo(BeNil())
+				}
+			})
+
+			ginkgo.It("should accept datemath format", func() {
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					BaseCatalogSearch: query.BaseCatalogSearch{
+						CatalogID: U.ID.String(),
+						Recursive: query.CatalogChangeRecursiveDownstream,
+					},
+					FromInsertedAt: "now-1h",
+				})
+				Expect(err).To(BeNil())
+				Expect(response.Total).To(BeNumerically(">=", 1))
+			})
+
+			ginkgo.It("should reject from_inserted_at after to_inserted_at", func() {
+				_, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					BaseCatalogSearch: query.BaseCatalogSearch{
+						CatalogID: U.ID.String(),
+						Recursive: query.CatalogChangeRecursiveDownstream,
+					},
+					FromInsertedAt: "2026-03-10T09:00:00Z",
+					ToInsertedAt:   "2026-03-09T09:00:00Z",
+				})
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
 		ginkgo.Context("created_at cursor filter", func() {
 			ginkgo.It("should accept RFC3339 with fractional seconds", func() {
 				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{

--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -447,21 +447,17 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 			Expect(response.Total).To(BeNumerically(">=", 1))
 		})
 
-		ginkgo.Context("inserted_at filter", func() {
+		ginkgo.Context("created_at cursor filter", func() {
 			ginkgo.It("should accept RFC3339 with fractional seconds", func() {
 				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
 					BaseCatalogSearch: query.BaseCatalogSearch{
 						CatalogID: U.ID.String(),
 						Recursive: query.CatalogChangeRecursiveDownstream,
+						From:      "2020-01-01T00:00:00.123456Z",
 					},
-					FromInsertedAt: "2026-03-09T09:02:00.76939Z",
 				})
 				Expect(err).To(BeNil())
 				Expect(response.Total).To(BeNumerically(">=", 1))
-
-				for _, c := range response.Changes {
-					Expect(c.InsertedAt).NotTo(BeNil())
-				}
 			})
 
 			ginkgo.It("should accept datemath format", func() {
@@ -469,21 +465,37 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 					BaseCatalogSearch: query.BaseCatalogSearch{
 						CatalogID: U.ID.String(),
 						Recursive: query.CatalogChangeRecursiveDownstream,
+						From:      "now-30m",
 					},
-					FromInsertedAt: "now-1h",
 				})
 				Expect(err).To(BeNil())
-				Expect(response.Total).To(BeNumerically(">=", 1))
+				// Only UChange (created at ~now) is within 30m; VChange is at now-1h
+				Expect(response.Total).To(BeNumerically("==", 1))
 			})
 
-			ginkgo.It("should reject from_inserted_at after to_inserted_at", func() {
+			ginkgo.It("should use exclusive comparison so the cursor item is not re-returned", func() {
+				cursor := UChange.CreatedAt.Format(time.RFC3339Nano)
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					BaseCatalogSearch: query.BaseCatalogSearch{
+						CatalogID: U.ID.String(),
+						Recursive: query.CatalogChangeRecursiveDownstream,
+						From:      cursor,
+					},
+				})
+				Expect(err).To(BeNil())
+				for _, c := range response.Changes {
+					Expect(c.ID).NotTo(Equal(UChange.ID))
+				}
+			})
+
+			ginkgo.It("should reject from after to", func() {
 				_, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
 					BaseCatalogSearch: query.BaseCatalogSearch{
 						CatalogID: U.ID.String(),
 						Recursive: query.CatalogChangeRecursiveDownstream,
+						From:      "2026-03-10T09:00:00Z",
+						To:        "2026-03-09T09:00:00Z",
 					},
-					FromInsertedAt: "2026-03-10T09:00:00Z",
-					ToInsertedAt:   "2026-03-09T09:00:00Z",
 				})
 				Expect(err).NotTo(BeNil())
 			})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Date filters now accept both RFC3339 and datemath formats with enhanced validation.
  * Error messages for invalid date inputs now clearly specify the expected formats.
  * Cursor-based pagination with `created_at` filtering now uses exclusive cursor semantics, ensuring the cursor point itself is excluded from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->