### PR TITLE
fix: make notification retries non-null with default 0

### DIFF
--- a/functions/pre_alter_columns.sql
+++ b/functions/pre_alter_columns.sql
@@ -48,3 +48,20 @@ BEGIN
         WHERE category IS NULL;
     END IF;
 END $$;
+
+DO $$
+BEGIN
+    -- Check if the column "retries" exists in the "notification_send_history" table
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = 'notification_send_history'
+        AND column_name = 'retries'
+    ) THEN
+        -- Update existing NULL values in the "retries" column
+        UPDATE notification_send_history
+        SET retries = 0
+        WHERE retries IS NULL;
+    END IF;
+END $$;

--- a/schema/notifications.hcl
+++ b/schema/notifications.hcl
@@ -208,7 +208,8 @@ table "notification_send_history" {
     type = timestamptz
   }
   column "retries" {
-    null    = true
+    null    = false
+    default = 0
     type    = integer
     comment = "number of retries of pending notifications"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved notification retry tracking. Enhanced the notification system to ensure all notification records maintain consistent and reliable retry counts, with automatic initialization to zero. This upgrade strengthens data integrity, prevents potential inconsistencies in notification delivery tracking, and improves overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->