### PR TITLE
fix: stop treating uuid.Nil as missing config in scraper lookup

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -538,10 +539,11 @@ type ConfigScraper struct {
 
 func FindScraperByConfigId(db *gorm.DB, configId string) (*ConfigScraper, error) {
 	var configItem ConfigItem
-	if err := db.Where("id = ?", configId).Find(&configItem).Error; err != nil {
+	if err := db.Where("id = ?", configId).First(&configItem).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("config item not found: %s", configId)
+		}
 		return nil, fmt.Errorf("failed to get config (%s): %w", configId, err)
-	} else if configItem.ID == uuid.Nil {
-		return nil, fmt.Errorf("config item not found: %s", configId)
 	}
 
 	if lo.FromPtr(configItem.ScraperID) == "" {
@@ -549,10 +551,11 @@ func FindScraperByConfigId(db *gorm.DB, configId string) (*ConfigScraper, error)
 	}
 
 	var scrapeConfig ConfigScraper
-	if err := db.Where("id = ?", lo.FromPtr(configItem.ScraperID)).Find(&scrapeConfig).Error; err != nil {
+	if err := db.Where("id = ?", lo.FromPtr(configItem.ScraperID)).First(&scrapeConfig).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("scraper not found: %s", lo.FromPtr(configItem.ScraperID))
+		}
 		return nil, fmt.Errorf("failed to get scrapeconfig (%s): %w", lo.FromPtr(configItem.ScraperID), err)
-	} else if scrapeConfig.ID.String() != lo.FromPtr(configItem.ScraperID) {
-		return nil, fmt.Errorf("scraper not found: %s", lo.FromPtr(configItem.ScraperID))
 	}
 
 	return &scrapeConfig, nil


### PR DESCRIPTION
- `uuid.Nil` is a valid `config_items.id` for the local agent’s ConfigItem.
- `FindScraperByConfigId` inferred not-found from `configItem.ID == uuid.Nil`, which misclassified that valid row.
- Switch to `First()` + `errors.Is(err, gorm.ErrRecordNotFound)` for both config and scraper lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for missing configuration items and scraper lookups
  * Improved reliability of scraper configuration retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->