### PR TITLE
fix(connection): export Azure bearer token cache field to avoid unstructured conversion panic

### DIFF
--- a/connection/azure.go
+++ b/connection/azure.go
@@ -18,10 +18,11 @@ type AzureConnection struct {
 	ClientSecret   *types.EnvVar `yaml:"clientSecret,omitempty" json:"clientSecret,omitempty"`
 	TenantID       string        `yaml:"tenantID,omitempty" json:"tenantID,omitempty"`
 
-	// bearerToken is populated from the referenced connection's
+	// BearerToken is populated from the referenced connection's
 	// Properties["bearer"] when the connection has no Username/Password set.
-	// It is an unexported fallback — not part of the inline YAML surface.
-	bearerToken string `json:"-" yaml:"-"`
+	//
+	// NOTE: Exported to avoid being flagged by CRD unexported-field validation.
+	BearerToken string `json:"-" yaml:"-"`
 }
 
 // HydrateConnection attempts to find the connection by name
@@ -44,7 +45,7 @@ func (g *AzureConnection) HydrateConnection(ctx ConnectionContext) error {
 		}
 
 		if connection.Username == "" && connection.Password == "" {
-			g.bearerToken = connection.Properties["bearer"]
+			g.BearerToken = connection.Properties["bearer"]
 		}
 	}
 
@@ -59,7 +60,7 @@ func (g *AzureConnection) FromModel(connection models.Connection) {
 		g.TenantID = tenantID
 	}
 	if connection.Username == "" && connection.Password == "" {
-		g.bearerToken = connection.Properties["bearer"]
+		g.BearerToken = connection.Properties["bearer"]
 	}
 }
 
@@ -78,8 +79,8 @@ func (g AzureConnection) ToModel() models.Connection {
 func (g *AzureConnection) TokenCredential() (azcore.TokenCredential, error) {
 	if (g.ClientID == nil || g.ClientID.IsEmpty()) &&
 		(g.ClientSecret == nil || g.ClientSecret.IsEmpty()) &&
-		g.bearerToken != "" {
-		return staticTokenCredential{token: g.bearerToken}, nil
+		g.BearerToken != "" {
+		return staticTokenCredential{token: g.BearerToken}, nil
 	}
 	return azidentity.NewClientSecretCredential(g.TenantID, g.ClientID.String(), g.ClientSecret.String(), nil)
 }


### PR DESCRIPTION
```
Mission Control reconciler decodes CRDs via apimachinery's
DefaultUnstructuredConverter (FromUnstructured). That reflection path
iterates struct fields and can call Set() while populating/zeroing them.
If a CRD-linked struct contains an unexported field, conversion can panic with:

  reflect: reflect.Value.Set using value obtained using unexported field

In this case, AzureConnection had an unexported fallback token cache field
(`bearerToken`). Export it to `BearerToken` so reflection can safely assign/zero
the field during decode.

Keep `json:"-" yaml:"-"` so the field remains out of serialized API payloads
and not part of user-facing CRD spec surface.

This mirrors the same class of issue previously addressed for HTTPConnection
(`awsConfig`), where custom Marshal/Unmarshal was not a safe long-term fix due
to promoted methods affecting embedded/sibling decoding.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Azure connection API structure to expose bearer token field for programmatic access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->