### PR TITLE
feat: add property-based job disable gate in runner

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -398,6 +398,11 @@ func (j *Job) Run() {
 		return
 	}
 
+	if j.Properties().On(false, j.getPropertyNames("disable")...) || j.Properties().On(false, j.getPropertyNames("disabled")...) {
+		ctx.Tracef("job disabled via properties")
+		return
+	}
+
 	r.start()
 	defer r.end()
 	if j.Singleton {

--- a/tests/job_test.go
+++ b/tests/job_test.go
@@ -47,6 +47,31 @@ var _ = Describe("Job", Ordered, func() {
 		Expect(counter.Load()).To(Equal(current + 1))
 	})
 
+	It("Should skip disabled jobs", func() {
+		var counter = atomic.Int32{}
+		disabledJob := &job.Job{
+			Name:       "test-disable",
+			Singleton:  true,
+			JobHistory: true,
+			Context:    DefaultContext,
+			Fn: func(ctx job.JobRuntime) error {
+				counter.Add(1)
+				return nil
+			},
+		}
+
+		before, err := disabledJob.FindHistory()
+		Expect(err).ToNot(HaveOccurred())
+
+		_ = context.UpdateProperty(DefaultContext, "jobs.test-disable.disable", "true")
+		disabledJob.Run()
+		Expect(counter.Load()).To(BeZero())
+
+		after, err := disabledJob.FindHistory()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(after).To(HaveLen(len(before)))
+	})
+
 	It("Should clean up jobs", func() {
 		items, _ := sampleJob.FindHistory()
 


### PR DESCRIPTION
- Adds jobs.<name>.disable / jobs.<name>.disabled handling in job.Run()\n- Disabled jobs return before execution and before history start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Jobs can now be disabled at runtime using context properties. Setting a disable or disabled flag for a job prevents execution and skips all startup and initialization procedures.

* **Tests**
  * Added comprehensive test coverage to verify that disabled jobs are properly handled, confirming no execution occurs and no history entries are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->