### PR TITLE
feat(job-history): add job_history_summary view

### DIFF
--- a/rbac/objects.go
+++ b/rbac/objects.go
@@ -121,6 +121,7 @@ var dbResourceObjMap = map[string]string{
 	"job_histories":                             policy.ObjectMonitor,
 	"job_history_latest_status":                 policy.ObjectMonitor,
 	"job_history_names":                         policy.ObjectMonitor,
+	"job_history_summary":                       policy.ObjectMonitor,
 	"job_history":                               policy.ObjectMonitor,
 	"logging_backends":                          policy.ObjectDatabaseSettings,
 	"migration_logs":                            policy.ObjectDatabaseSystem,

--- a/views/015_job_history.sql
+++ b/views/015_job_history.sql
@@ -198,6 +198,22 @@ CREATE OR REPLACE VIEW job_history_names AS
   SELECT distinct on (name) name
   FROM job_history;
 
+DROP VIEW IF EXISTS job_history_summary;
+CREATE OR REPLACE VIEW job_history_summary AS
+SELECT
+  name,
+  COUNT(*) AS total,
+  COUNT(*) FILTER (WHERE status = 'RUNNING') AS running,
+  COUNT(*) FILTER (WHERE status = 'SUCCESS') AS success,
+  COUNT(*) FILTER (WHERE status = 'WARNING') AS warning,
+  COUNT(*) FILTER (WHERE status = 'FAILED') AS failed,
+  COUNT(*) FILTER (WHERE status = 'STALE') AS stale,
+  COUNT(*) FILTER (WHERE status = 'SKIPPED') AS skipped,
+  MAX(created_at) AS last_run_at,
+  ROUND(AVG(duration_millis::numeric), 2) AS average_duration
+FROM job_history
+GROUP BY name;
+
 -- Notifications with job history
 DROP VIEW IF EXISTS notifications_summary;
 


### PR DESCRIPTION
Adds a new `job_history_summary` view grouped by `name`, including:
- total jobs
- per-status counts (`running`, `success`, `warning`, `failed`, `stale`, `skipped`)
- `last_run_at`
- `average_duration`

Also maps `job_history_summary` in RBAC (`policy.ObjectMonitor`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job history summary view providing aggregated statistics including total job count, per-status breakdown (running, success, warning, failed, stale, skipped), last run timestamp, and average duration metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->