### PR TITLE
fix: avoid concurrent map mutation in notification CEL context

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -1,6 +1,8 @@
 package duty
 
 import (
+	"maps"
+
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
@@ -33,7 +35,7 @@ func GetResourceContext(ctx context.Context, resource types.ResourceSelectable) 
 		}
 		if table, ok := resource.(models.TaggableModel); ok {
 			if tableTags := table.GetTags(); tableTags != nil {
-				tags = tableTags
+				tags = maps.Clone(tableTags)
 			}
 		}
 		if table, ok := resource.(models.LabelableModel); ok {


### PR DESCRIPTION
Notification event consumers build CEL variables via duty.GetResourceContext().

When a resource exposed its tags map, GetResourceContext reused that same map and then appended missing distinct tag keys for template variables.

Under concurrent notification processing, that mutated a shared map and caused runtime panics (internal/runtime/maps.fatal) while resolving notification/group membership.

This change clones resource tags before enrichment so each evaluation works on an isolated map.

resolves: https://github.com/flanksource/mission-control/issues/2988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where resource tags could be unintentionally modified during processing, ensuring tag data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->