### PR TITLE
fix: emit postq metrics for pre-handler event consumption errors

### DIFF
--- a/postq/async_consumer.go
+++ b/postq/async_consumer.go
@@ -50,9 +50,17 @@ func (t *AsyncEventConsumer) Handle(ctx context.Context) (int, error) {
 	tx := ctx.DB().Begin()
 	defer tx.Rollback() //nolint:errcheck
 
+	if tx.Error != nil {
+		err := fmt.Errorf("error starting transaction: %w", tx.Error)
+		recordPreHandlerError(ctx, "async", t.WatchEvents, err)
+		return 0, err
+	}
+
 	events, err := fetchEvents(ctx, tx, t.WatchEvents, t.BatchSize, t.EventFetcherOption)
 	if err != nil {
-		return 0, fmt.Errorf("error fetching events: %w", err)
+		err = fmt.Errorf("error fetching events: %w", err)
+		recordPreHandlerError(ctx, "async", t.WatchEvents, err)
+		return 0, err
 	}
 
 	if t.eventLog != nil {

--- a/postq/metrics.go
+++ b/postq/metrics.go
@@ -1,0 +1,54 @@
+package postq
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/flanksource/duty/context"
+)
+
+const preHandlerErrorsMetricName = "postq_prehandler_errors_total"
+
+func recordPreHandlerError(ctx context.Context, consumer string, watchEvents []string, err error) {
+	ctx.Counter(
+		preHandlerErrorsMetricName,
+		"consumer", consumer,
+		"event", eventMetricLabel(watchEvents),
+		"kind", classifyPreHandlerError(err),
+	).Add(1)
+}
+
+func eventMetricLabel(events []string) string {
+	if len(events) == 0 {
+		return "unknown"
+	}
+
+	if len(events) == 1 {
+		return events[0]
+	}
+
+	copyEvents := append([]string(nil), events...)
+	slices.Sort(copyEvents)
+	return strings.Join(copyEvents, "|")
+}
+
+func classifyPreHandlerError(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+
+	e := strings.ToLower(err.Error())
+
+	switch {
+	case strings.Contains(e, "scan error"),
+		strings.Contains(e, "cannot unmarshal"),
+		strings.Contains(e, "unsupported scan"):
+		return "scan_decode"
+	case strings.Contains(e, "error starting transaction"):
+		return "tx_begin"
+	case strings.Contains(e, "error fetching events"):
+		return "fetch"
+	default:
+		return "other"
+	}
+}

--- a/postq/sync_consumer.go
+++ b/postq/sync_consumer.go
@@ -76,9 +76,17 @@ func (t *SyncEventConsumer) consumeEvent(ctx context.Context) (*models.Event, er
 	tx := ctx.DB().Begin()
 	defer tx.Rollback()
 
+	if tx.Error != nil {
+		err := fmt.Errorf("error starting transaction: %w", tx.Error)
+		recordPreHandlerError(ctx, "sync", t.WatchEvents, err)
+		return nil, err
+	}
+
 	events, err := fetchEvents(ctx, tx, t.WatchEvents, 1, t.EventFetchOption)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching events: %w", err)
+		err = fmt.Errorf("error fetching events: %w", err)
+		recordPreHandlerError(ctx, "sync", t.WatchEvents, err)
+		return nil, err
 	}
 
 	if len(events) == 0 {


### PR DESCRIPTION
This issue surfaced when event queue rows failed to scan before handler execution (e.g. `properties` JSON containing non-string values).

Root cause: only handler-level metrics existed; failures in transaction start/fetch/scan paths were only logged and not metrically visible.

This change adds `postq_prehandler_errors_total` in `duty/postq` and increments it from sync/async consumers when pre-handler failures occur.

The metric includes low-cardinality labels for `consumer`, `event`, and `kind` so scan/decode and other fetch-path failures are observable across all postq consumers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for transaction initialization and event fetching in message processing. Failures are now explicitly detected and properly tracked for better error monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->