### PR TITLE
fix: create only 1 event for config db health changes

### DIFF
--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -565,6 +565,13 @@ $$
 DECLARE
   event_name TEXT := 'config.changed';
 BEGIN
+  -- Health-driven config_changes rows are already announced via the
+  -- config.<health> event enqueued by config_health_event_enqueue, so
+  -- suppress the duplicate config.changed event here.
+  IF NEW.source = 'config-db-health-trigger' THEN
+    RETURN NEW;
+  END IF;
+
   IF NEW.change_type = 'diff' THEN
     event_name := 'config.updated';
   END IF;

--- a/views/029_config_triggers.sql
+++ b/views/029_config_triggers.sql
@@ -61,7 +61,7 @@ BEGIN
   INSERT INTO config_changes (config_id, change_type, source, count, severity, summary, details) VALUES (
     NEW.id,
     change_type,
-    'config-db',
+    'config-db-health-trigger',
     1,
     severity,
     summary,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate event queue entries for configuration changes initiated by system health monitoring, improving data integrity and reducing redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->