### PR TITLE
chore: revert event generation logic on new config health updates

### DIFF
--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -252,8 +252,9 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 			})
 			Expect(err).To(BeNil())
 
-			Expect(response.Total).To(Equal(int64(3)))
-			Expect(len(response.Changes)).To(Equal(3))
+			Expect(response.Total).To(Equal(int64(8)))
+			Expect(len(response.Changes)).To(Equal(8))
+			Expect(response.Summary["Healthy"]).To(Equal(5))
 			Expect(response.Summary["Pulled"]).To(Equal(2))
 			Expect(response.Summary["diff"]).To(Equal(1))
 		})

--- a/tests/config_type_summary_test.go
+++ b/tests/config_type_summary_test.go
@@ -233,8 +233,8 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 		Expect(err).To(BeNil())
 
 		expectedTypeSummary10d := []summaryRow{
-			{Type: "Test::type-A", Count: 3, Changes: 6, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
-			{Type: "Test::type-B", Count: 2, Changes: 6, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
+			{Type: "Test::type-A", Count: 3, Changes: 8, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
+			{Type: "Test::type-B", Count: 2, Changes: 8, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
 			{Type: "Test::type-C", Count: 1, Changes: 1, Health: map[string]any{"unhealthy": float64(1)}, Analysis: nil},
 		}
 

--- a/tests/config_type_summary_test.go
+++ b/tests/config_type_summary_test.go
@@ -65,7 +65,6 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 			{
 				configClass:  models.ConfigClassNode,
 				totalConfigs: 3,
-				changes:      lo.ToPtr(1),
 				cp30d:        lo.ToPtr(2.5),
 			},
 			{

--- a/tests/config_type_summary_test.go
+++ b/tests/config_type_summary_test.go
@@ -65,6 +65,7 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 			{
 				configClass:  models.ConfigClassNode,
 				totalConfigs: 3,
+				changes:      lo.ToPtr(1),
 				cp30d:        lo.ToPtr(2.5),
 			},
 			{

--- a/tests/config_type_summary_test.go
+++ b/tests/config_type_summary_test.go
@@ -141,8 +141,8 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 		Expect(err).To(BeNil())
 
 		expectedTypeSummary := []summaryRow{
-			{Type: "Test::type-A", Count: 3, Changes: 7, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(3), "security": float64(2)}},
-			{Type: "Test::type-B", Count: 2, Changes: 6, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
+			{Type: "Test::type-A", Count: 3, Changes: 9, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(3), "security": float64(2)}},
+			{Type: "Test::type-B", Count: 2, Changes: 8, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
 			{Type: "Test::type-C", Count: 1, Changes: 1, Health: map[string]any{"unhealthy": float64(1)}, Analysis: map[string]any{}},
 		}
 
@@ -179,8 +179,8 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 		Expect(err).To(BeNil())
 
 		expectedTypeSummary7d := []summaryRow{
-			{Type: "Test::type-A", Count: 3, Changes: 6, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
-			{Type: "Test::type-B", Count: 2, Changes: 6, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
+			{Type: "Test::type-A", Count: 3, Changes: 8, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
+			{Type: "Test::type-B", Count: 2, Changes: 8, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
 			{Type: "Test::type-C", Count: 1, Changes: 1, Health: map[string]any{"unhealthy": float64(1)}, Analysis: map[string]any{}},
 		}
 
@@ -206,8 +206,8 @@ var _ = ginkgo.Describe("Check config_class_summary view", ginkgo.Ordered, func(
 		Expect(err).To(BeNil())
 
 		expectedTypeSummary3d := []summaryRow{
-			{Type: "Test::type-A", Count: 3, Changes: 6, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
-			{Type: "Test::type-B", Count: 2, Changes: 6, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
+			{Type: "Test::type-A", Count: 3, Changes: 8, Health: map[string]any{"healthy": float64(2), "unhealthy": float64(1)}, Analysis: map[string]any{"availability": float64(2), "cost": float64(2), "security": float64(2)}},
+			{Type: "Test::type-B", Count: 2, Changes: 8, Health: map[string]any{"healthy": float64(2)}, Analysis: map[string]any{"availability": float64(1), "cost": float64(1), "security": float64(2)}},
 			{Type: "Test::type-C", Count: 1, Changes: 1, Health: map[string]any{"unhealthy": float64(1)}, Analysis: map[string]any{}},
 		}
 

--- a/tests/fixtures/dummy/config_changes.go
+++ b/tests/fixtures/dummy/config_changes.go
@@ -58,18 +58,6 @@ var KubernetesNodeAChange = models.ConfigChange{
 	FirstObserved: &DummyYearOldDate,
 }
 
-var KubernetesNodeARecentChange = models.ConfigChange{
-	ID:            uuid.New().String(),
-	ConfigID:      KubernetesNodeA.ID.String(),
-	ChangeType:    types.ChangeTypeUpdate,
-	CreatedAt:     lo.ToPtr(DummyNow.Add(-time.Hour * 24)),
-	Severity:      models.SeverityInfo,
-	Source:        "Kubernetes",
-	Summary:       "Kubernetes node labels updated",
-	Count:         1,
-	FirstObserved: lo.ToPtr(DummyNow.Add(-time.Hour * 24)),
-}
-
 // Nginx Helm Release version upgrade changes
 var NginxHelmReleaseUpgradeV1 = models.ConfigChange{
 	ID:            uuid.New().String(),
@@ -153,7 +141,6 @@ var AllDummyConfigChanges = []models.ConfigChange{
 	EKSClusterUpdateChange,
 	EKSClusterDeleteChange,
 	KubernetesNodeAChange,
-	KubernetesNodeARecentChange,
 	NginxHelmReleaseUpgradeV1,
 	NginxHelmReleaseUpgradeV2,
 	NginxHelmReleaseUpgradeV3,

--- a/views/029_config_triggers.sql
+++ b/views/029_config_triggers.sql
@@ -30,13 +30,7 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  -- On INSERT, only record health transitions that produce an event
-  -- (matches the gate in insert_config_health_updates_in_event_queue).
-  IF TG_OP = 'INSERT' AND NEW.health NOT IN ('warning', 'unhealthy') THEN
-    RETURN NULL;
-  END IF;
-
-  IF OLD.health = NEW.health OR (OLD.health IS NULL AND NEW.health IS NULL) THEN
+  IF OLD.health = NEW.health OR (OLD.health IS NULL AND NEW.health IS NULL) OR (OLD IS NULL AND NEW.health = 'unknown') THEN
     RETURN NULL;
   END IF;
 


### PR DESCRIPTION
Reverts flanksource/duty#1910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration health change detection by refining trigger conditions for edge cases

* **Tests**
  * Updated test expectations for configuration change queries and type-based analysis
  * Modified test fixtures for configuration tracking scenarios

* **Chores**
  * Removed unused test fixture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->