### PR TITLE
feat(artifacts): add scraper and job history provenance links

### DIFF
--- a/models/artifacts.go
+++ b/models/artifacts.go
@@ -18,25 +18,35 @@ import (
 
 // Artifact represents the artifacts table
 type Artifact struct {
-	ID                  uuid.UUID  `json:"id" gorm:"default:generate_ulid()"`
-	CheckID             *uuid.UUID `json:"check_id,omitempty"`
-	CheckTime           *time.Time `json:"check_time,omitempty" time_format:"postgres_timestamp"`
+	ID             uuid.UUID  `json:"id" gorm:"default:generate_ulid()"`
+	CheckID        *uuid.UUID `json:"check_id,omitempty"`
+	CheckTime      *time.Time `json:"check_time,omitempty" time_format:"postgres_timestamp"`
+	ConfigChangeID *uuid.UUID `json:"config_change_id,omitempty"`
+
+	// Playbook action that created this artifact
 	PlaybookRunActionID *uuid.UUID `json:"playbook_run_action_id,omitempty"`
-	ConfigChangeID      *uuid.UUID `json:"config_change_id,omitempty"`
-	ConnectionID        uuid.UUID  `json:"connection_id,omitempty"`
-	Path                string     `json:"path"`
-	IsPushed            bool       `json:"is_pushed"`
-	IsDataPushed        bool       `json:"is_data_pushed"`
-	Filename            string     `json:"filename"`
-	Size                int64      `json:"size"` // Size in bytes
-	ContentType         string     `json:"content_type,omitempty"`
-	Checksum            string     `json:"checksum"`
-	Content             []byte     `json:"-" gorm:"type:bytea"`
-	CompressionType     string     `json:"compression_type,omitempty"`
-	CreatedAt           time.Time  `json:"created_at" yaml:"created_at" time_format:"postgres_timestamp"`
-	UpdatedAt           time.Time  `json:"updated_at" yaml:"updated_at" time_format:"postgres_timestamp"`
-	DeletedAt           *time.Time `json:"deleted_at,omitempty" yaml:"deleted_at,omitempty" time_format:"postgres_timestamp"`
-	ExpiresAt           *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty" time_format:"postgres_timestamp"`
+
+	// ScraperID is the durable owner for scraper-generated artifacts.
+	ScraperID *uuid.UUID `json:"scraper_id,omitempty"`
+
+	// JobHistoryID records the creating job run provenance for scraper-generated artifacts.
+	// It may become nil when job_history retention prunes old rows.
+	JobHistoryID *uuid.UUID `json:"job_history_id,omitempty"`
+
+	ConnectionID    uuid.UUID  `json:"connection_id,omitempty"`
+	Path            string     `json:"path"`
+	IsPushed        bool       `json:"is_pushed"`
+	IsDataPushed    bool       `json:"is_data_pushed"`
+	Filename        string     `json:"filename"`
+	Size            int64      `json:"size"` // Size in bytes
+	ContentType     string     `json:"content_type,omitempty"`
+	Checksum        string     `json:"checksum"`
+	Content         []byte     `json:"-" gorm:"type:bytea"`
+	CompressionType string     `json:"compression_type,omitempty"`
+	CreatedAt       time.Time  `json:"created_at" yaml:"created_at" time_format:"postgres_timestamp"`
+	UpdatedAt       time.Time  `json:"updated_at" yaml:"updated_at" time_format:"postgres_timestamp"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty" yaml:"deleted_at,omitempty" time_format:"postgres_timestamp"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty" time_format:"postgres_timestamp"`
 }
 
 func (a Artifact) TableName() string {

--- a/schema/artifacts.hcl
+++ b/schema/artifacts.hcl
@@ -21,6 +21,16 @@ table "artifacts" {
     null = true
     type = uuid
   }
+  column "scraper_id" {
+    null    = true
+    type    = uuid
+    comment = "durable owner for scraper-generated artifacts; references config_scrapers"
+  }
+  column "job_history_id" {
+    null    = true
+    type    = uuid
+    comment = "creator/provenance job run for scraper-generated artifacts; set null when job_history rows are pruned"
+  }
   column "connection_id" {
     null    = true
     type    = uuid
@@ -107,6 +117,18 @@ table "artifacts" {
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
+  foreign_key "artifacts_scraper_fkey" {
+    columns     = [column.scraper_id]
+    ref_columns = [table.config_scrapers.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "artifacts_job_history_fkey" {
+    columns     = [column.job_history_id]
+    ref_columns = [table.job_history.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
   index "artifacts_check_id_idx" {
     columns = [column.check_id]
   }
@@ -115,5 +137,11 @@ table "artifacts" {
   }
   index "artifacts_config_change_id_idx" {
     columns = [column.config_change_id]
+  }
+  index "artifacts_scraper_id_idx" {
+    columns = [column.scraper_id]
+  }
+  index "artifacts_job_history_id_idx" {
+    columns = [column.job_history_id]
   }
 }


### PR DESCRIPTION
- Add nullable `artifacts.scraper_id` and `artifacts.job_history_id`.
- Model ownership/provenance semantics explicitly:
  - `scraper_id` = durable owner for scraper-generated artifacts
  - `job_history_id` = creating run provenance
- Set FK behavior for retention/lifecycle:
  - `scraper_id -> config_scrapers(id) ON DELETE CASCADE`
  - `job_history_id -> job_history(id) ON DELETE SET NULL`
- Add schema + model comments to document semantics.