### PR TITLE
fix: buffer S3 PutObject body to ensure seekability

### DIFF
--- a/artifact/fs/s3.go
+++ b/artifact/fs/s3.go
@@ -1,7 +1,9 @@
 package fs
 
 import (
+	"bytes"
 	gocontext "context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -126,10 +128,16 @@ func (t *s3FS) Read(ctx gocontext.Context, key string) (io.ReadCloser, error) {
 }
 
 func (t *s3FS) Write(ctx gocontext.Context, path string, data io.Reader) (os.FileInfo, error) {
-	_, err := t.Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(t.Bucket),
-		Key:    aws.String(path),
-		Body:   data,
+	content, err := io.ReadAll(data)
+	if err != nil {
+		return nil, fmt.Errorf("reading data for %s: %w", path, err)
+	}
+
+	_, err = t.Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(t.Bucket),
+		Key:           aws.String(path),
+		Body:          bytes.NewReader(content),
+		ContentLength: aws.Int64(int64(len(content))),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- S3 artifact uploads fail because `blobStore.Write` wraps the original
  seekable `bytes.Reader` in a TeeReader chain (for checksum and MIME
  detection), producing a plain `io.Reader` that the AWS SDK v2 cannot use.
- The SDK requires a seekable body for SigV4 payload hashing and content
  length computation. Without it, requests fail with:
  - `MissingContentLength` (HTTP 411) against S3-compatible servers
  - `failed to compute payload hash: request stream is not seekable`
  - `unseekable stream is not supported without TLS and trailing checksum`
- Buffer the reader with `io.ReadAll` + `bytes.NewReader` in the S3 `Write`
  method, consistent with how the GCS and Azure implementations already
  handle their writes.