### PR TITLE
chore: add property registry and linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,13 @@ fmt:
 	go fmt ./...
 
 .PHONY: lint
-lint: golangci-lint
+lint: golangci-lint property-lint
 	$(GOLANGCI_LINT) run ./...
 	go vet ./...
+
+.PHONY: property-lint
+property-lint:
+	go run ./hack/propertylint .
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/api/properties_registry.go
+++ b/api/properties_registry.go
@@ -1,0 +1,64 @@
+package api
+
+const (
+	PropertyArtifactsConnection = "artifacts.connection"
+
+	PropertyCasbinAutoSave            = "casbin.auto.save"
+	PropertyCasbinCache               = "casbin.cache"
+	PropertyCasbinCacheExpiry         = "casbin.cache.expiry"
+	PropertyCasbinCacheReloadInterval = "casbin.cache.reload.interval"
+	PropertyCasbinExplain             = "casbin.explain"
+	PropertyCasbinLogLevel            = "casbin.log.level"
+
+	PropertyConfigTraversalCacheExpiryMax = "config.traversal.cache_expiry.max"
+	PropertyConfigTraversalCacheExpiryMin = "config.traversal.cache_expiry.min"
+
+	PropertyDBConnectionTimeout = "db.connection.timeout"
+	PropertyDBMigrateSkip       = "db.migrate.skip"
+	PropertyDBPostgrestTimeout  = "db.postgrest.timeout"
+
+	PropertyEnvvarCacheTimeout     = "envvar.cache.timeout"
+	PropertyEnvvarHelmCacheTimeout = "envvar.helm.cache.timeout"
+	PropertyEnvvarLookupLog        = "envvar.lookup.log"
+	PropertyEnvvarLookupTimeout    = "envvar.lookup.timeout"
+
+	PropertyJobEvictionPeriod               = "job.eviction.period"
+	PropertyJobHistoryAgentCleanupBatchSize = "job_history.agent_cleanup.batch_size"
+	PropertyJobJitterDisable                = "job.jitter.disable"
+	PropertyJobResetIsPushedIgnoreDeletedAt = "job.ResetIsPushed.ignore_deleted_at"
+	PropertyJobResetIsPushedIntervalDays    = "job.ResetIsPushed.interval_days"
+
+	PropertyKubernetesCacheTimeout = "kubernetes.cache.timeout"
+
+	PropertyLeaderLeaseDuration = "leader.lease.duration"
+
+	PropertyLogDBMaxLength           = "log.db.maxLength"
+	PropertyLogDBParams              = "log.db.params"
+	PropertyLogDBSlowThreshold       = "log.db.slowThreshold"
+	PropertyLogLevelResourceSelector = "log.level.resourceSelector"
+
+	PropertyMemoryStats = "memory.stats"
+
+	PropertyQueryLog = "query.log"
+
+	PropertySecretKeeperCacheTTL = "secretkeeper.cache.ttl"
+
+	PropertyShellAllowedEnvs                 = "shell.allowed.envs"
+	PropertyShellConnectionWaitBeforeCleanup = "shell.connection.wait_before_cleanup"
+	PropertyShellJQTimeout                   = "shell.jq.timeout"
+	PropertyShellYQTimeout                   = "shell.yq.timeout"
+
+	PropertyTopologyCacheAge     = "topology.cache.age"
+	PropertyTopologyQueryTimeout = "topology.query.timeout"
+
+	PropertyUpdateIsPushedBatchSize = "update_is_pushed.batch.size"
+
+	PropertyUpstreamClientCacheViewColumns = "upstream.client.cache.view-columns.duration"
+	PropertyUpstreamSummaryFKErrorIDCount  = "upstream.summary.fkerror_id_count"
+
+	PropertyViewHTTPBodyMaxSizeBytes = "view.http.body.max_size_bytes"
+)
+
+const (
+	PropertyJobsPrefix = "jobs."
+)

--- a/context/blobs.go
+++ b/context/blobs.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"fmt"
+	"github.com/flanksource/duty/api"
 
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/artifact"
@@ -17,7 +18,7 @@ var BlobStoreProvider func(ctx Context, connURL string) (artifact.BlobStore, err
 // If an artifacts.connection property is configured and a provider is registered,
 // it returns the external backend. Otherwise it returns the inline DB-backed store.
 func (k Context) Blobs() (artifact.BlobStore, error) {
-	connURL := k.Properties().String("artifacts.connection", "")
+	connURL := k.Properties().String(api.PropertyArtifactsConnection, "")
 	if connURL == "" {
 		blobsLogger.Infof("Initializing inline blob store")
 		store := artifact.NewBlobStore(artifact.NewInlineStore(k.DB()), k.DB(), "inline")

--- a/context/envvar.go
+++ b/context/envvar.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"strings"
 	"time"
 
@@ -31,7 +32,7 @@ func GetEnvValueFromCache(ctx Context, input types.EnvVar, namespace string) (va
 	if input.IsEmpty() {
 		return "", nil
 	}
-	ctx, cancel := ctx.WithTimeout(ctx.Properties().Duration("envvar.lookup.timeout", 5*time.Second))
+	ctx, cancel := ctx.WithTimeout(ctx.Properties().Duration(api.PropertyEnvvarLookupTimeout, 5*time.Second))
 	defer cancel()
 	if namespace == "" {
 		namespace = ctx.GetNamespace()
@@ -57,7 +58,7 @@ func GetEnvValueFromCache(ctx Context, input types.EnvVar, namespace string) (va
 
 	if err != nil {
 		ctx.Logger.V(3).Infof("lookup[%s] failed %s => %s", input.Name, source, err.Error())
-	} else if ctx.Logger.IsLevelEnabled(2) && properties.On(false, "envvar.lookup.log") {
+	} else if ctx.Logger.IsLevelEnabled(2) && properties.On(false, api.PropertyEnvvarLookupLog) {
 		ctx.Logger.V(5).Infof("lookup[%s] %s => %s", input.Name, source, logger.PrintableSecret(value))
 	}
 
@@ -157,7 +158,7 @@ func GetHelmValueFromCache(ctx Context, namespace, releaseName, key string) (str
 		}
 	}
 
-	envCache.Set(id, val, ctx.Properties().Duration("envvar.helm.cache.timeout", ctx.Properties().Duration("envvar.cache.timeout", 5*time.Minute)))
+	envCache.Set(id, val, ctx.Properties().Duration(api.PropertyEnvvarHelmCacheTimeout, ctx.Properties().Duration(api.PropertyEnvvarCacheTimeout, 5*time.Minute)))
 	return val, nil
 }
 
@@ -188,7 +189,7 @@ func GetSecretFromCache(ctx Context, namespace, name, key string) (string, error
 	if !ok {
 		return "", fmt.Errorf("could not find key %v in secret %s/%s (%s)", key, namespace, name, strings.Join(lo.Keys(secret.Data), ", "))
 	}
-	envCache.Set(id, string(value), ctx.Properties().Duration("envvar.cache.timeout", 5*time.Minute))
+	envCache.Set(id, string(value), ctx.Properties().Duration(api.PropertyEnvvarCacheTimeout, 5*time.Minute))
 	return string(value), nil
 }
 
@@ -214,7 +215,7 @@ func GetConfigMapFromCache(ctx Context, namespace, name, key string) (string, er
 		return "", fmt.Errorf("could not find key %v in configmap %s/%s (%s)", key, namespace, name,
 			strings.Join(lo.Keys(configMap.Data), ", "))
 	}
-	envCache.Set(id, string(value), ctx.Properties().Duration("envvar.cache.timeout", 5*time.Minute))
+	envCache.Set(id, string(value), ctx.Properties().Duration(api.PropertyEnvvarCacheTimeout, 5*time.Minute))
 	return string(value), nil
 }
 

--- a/db.go
+++ b/db.go
@@ -359,7 +359,7 @@ func verifyKratosMigration(db *gorm.DB) error {
 }
 
 func setStatementTimeouts(ctx dutyContext.Context, config api.Config) {
-	postgrestTimeout := ctx.Properties().Duration("db.postgrest.timeout", 1*time.Minute)
+	postgrestTimeout := ctx.Properties().Duration(api.PropertyDBPostgrestTimeout, 1*time.Minute)
 
 	if err := ctx.DB().Raw(fmt.Sprintf(`ALTER ROLE %s SET statement_timeout = '%0fs'`, config.Postgrest.DBRole, postgrestTimeout.Seconds())).Error; err != nil {
 		logger.Errorf(err.Error())
@@ -371,7 +371,7 @@ func setStatementTimeouts(ctx dutyContext.Context, config api.Config) {
 		}
 	}
 
-	statementTimeout := ctx.Properties().Duration("db.connection.timeout", 1*time.Hour)
+	statementTimeout := ctx.Properties().Duration(api.PropertyDBConnectionTimeout, 1*time.Hour)
 	if username := config.GetUsername(); username != "" {
 		if err := ctx.DB().Raw(fmt.Sprintf(`ALTER ROLE %s SET statement_timeout = '%0fs'`, username, statementTimeout.Seconds())).Error; err != nil {
 			logger.Errorf(err.Error())

--- a/echo/debug.go
+++ b/echo/debug.go
@@ -3,6 +3,7 @@ package echo
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -151,7 +152,7 @@ func AddDebugHandlers(ctx context.Context, e *echo.Echo, rbac echo.MiddlewareFun
 
 	debug.GET("/cron", CronDetailsHandler())
 
-	if period := properties.Duration(0, "memory.stats"); period > 0 {
+	if period := properties.Duration(0, api.PropertyMemoryStats); period > 0 {
 		timer := timer.NewMemoryTimer()
 		go func() {
 			for {

--- a/gorm/logger.go
+++ b/gorm/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"strings"
 	"time"
 
@@ -94,12 +95,12 @@ func NewSqlLogger(logger *commons.SlogLogger) logger.Interface {
 	return &SqlLogger{
 		Config: Config{
 			Colorful:                  true,
-			SlowThreshold:             properties.Duration(time.Second, "log.db.slowThreshold"),
+			SlowThreshold:             properties.Duration(time.Second, api.PropertyLogDBSlowThreshold),
 			IgnoreRecordNotFoundError: true,
 		},
 		Logger:      logger,
-		traceParams: logger.IsTraceEnabled() || properties.On(false, "log.db.params"),
-		maxLength:   properties.Int(1024, "log.db.maxLength"),
+		traceParams: logger.IsTraceEnabled() || properties.On(false, api.PropertyLogDBParams),
+		maxLength:   properties.Int(1024, api.PropertyLogDBMaxLength),
 		baseLevel:   commons.Info,
 	}
 }

--- a/hack/propertylint/main.go
+++ b/hack/propertylint/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+func main() {
+	flag.Parse()
+	roots := flag.Args()
+	if len(roots) == 0 {
+		roots = []string{"."}
+	}
+
+	var violations []string
+	for _, root := range roots {
+		v, err := lintRoot(root)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		violations = append(violations, v...)
+	}
+
+	if len(violations) > 0 {
+		fmt.Fprintln(os.Stderr, "property keys must use api.Property* constants, not string literals:")
+		for _, violation := range violations {
+			fmt.Fprintln(os.Stderr, "  "+violation)
+		}
+		os.Exit(1)
+	}
+}
+
+func lintRoot(root string) ([]string, error) {
+	var violations []string
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".bin", "tmp", "schema":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			for _, arg := range propertyKeyArgs(call) {
+				if containsStringLiteral(arg) {
+					pos := fset.Position(arg.Pos())
+					violations = append(violations, fmt.Sprintf("%s:%d", filepath.ToSlash(pos.Filename), pos.Line))
+				}
+			}
+			return true
+		})
+
+		return nil
+	})
+	return violations, err
+}
+
+func propertyKeyArgs(call *ast.CallExpr) []ast.Expr {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !slices.Contains([]string{"Duration", "Int", "String", "On", "Off"}, selector.Sel.Name) {
+		return nil
+	}
+
+	if isCommonsPropertiesCall(selector) {
+		if len(call.Args) < 2 {
+			return nil
+		}
+		return call.Args[1:]
+	}
+
+	if isHierarchicalPropertiesCall(selector) {
+		switch selector.Sel.Name {
+		case "On":
+			if len(call.Args) < 2 {
+				return nil
+			}
+			return call.Args[1:]
+		default:
+			if len(call.Args) == 0 {
+				return nil
+			}
+			return call.Args[:1]
+		}
+	}
+
+	return nil
+}
+
+func isCommonsPropertiesCall(selector *ast.SelectorExpr) bool {
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && ident.Name == "properties"
+}
+
+func isHierarchicalPropertiesCall(selector *ast.SelectorExpr) bool {
+	call, ok := selector.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	innerSelector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && innerSelector.Sel.Name == "Properties"
+}
+
+func containsStringLiteral(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		lit, ok := n.(*ast.BasicLit)
+		if ok && lit.Kind == token.STRING {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/job/cleanup.go
+++ b/job/cleanup.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"time"
 
 	"github.com/flanksource/commons/properties"
@@ -38,7 +39,7 @@ func CleanupStaleHistory(
 }
 
 func CleanupStaleAgentHistory(ctx context.Context, itemsToRetain int) (int, error) {
-	batchSize := properties.Int(2000, "job_history.agent_cleanup.batch_size")
+	batchSize := properties.Int(2000, api.PropertyJobHistoryAgentCleanupBatchSize)
 	query := fmt.Sprintf(`
         WITH grouped_history AS (
             SELECT

--- a/job/job.go
+++ b/job/job.go
@@ -4,6 +4,7 @@ import (
 	"container/ring"
 	gocontext "context"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -30,6 +31,15 @@ const (
 	ResourceTypePlaybook      = "playbook"
 	ResourceTypeScraper       = "config_scraper"
 	ResourceTypeUpstream      = "upstream"
+
+	propertyNameSeparator = "."
+
+	jobPropertyDebug     = "debug"
+	jobPropertyDisable   = "disable"
+	jobPropertyDisabled  = "disabled"
+	jobPropertyHistory   = "history"
+	jobPropertySingleton = "singleton"
+	jobPropertyTrace     = "trace"
 )
 
 const (
@@ -69,7 +79,7 @@ func StartJobHistoryEvictor(ctx context.Context) {
 // deleteEvictedJobs deletes job_history rows from the DB every job.eviction.period(1m),
 // jobs send rows to be deleted by maintaining a circular buffer by status type
 func deleteEvictedJobs(ctx context.Context) {
-	period := ctx.Properties().Duration("job.eviction.period", time.Minute)
+	period := ctx.Properties().Duration(api.PropertyJobEvictionPeriod, time.Minute)
 	ctx = ctx.WithoutTracing().WithName("jobs").WithDBLogger("jobs", logger.Trace1)
 	ctx.Infof("Cleaning up jobs every %v", period)
 	for {
@@ -358,7 +368,7 @@ func (j *Job) SetID(id string) *Job {
 }
 
 func (j *Job) Run() {
-	if !j.Context.Properties().On(false, "job.jitter.disable") && !j.JitterDisable && j.Schedule != "" {
+	if !j.Context.Properties().On(false, api.PropertyJobJitterDisable) && !j.JitterDisable && j.Schedule != "" {
 		// Attempt to get a fixed interval from the schedule to measure the appropriate jitter.
 		// NOTE: Only works for fixed interval schedules.
 		parsedSchedule, err := cron.ParseStandard(j.Schedule)
@@ -398,7 +408,7 @@ func (j *Job) Run() {
 		return
 	}
 
-	if j.Properties().On(false, j.getPropertyNames("disable")...) || j.Properties().On(false, j.getPropertyNames("disabled")...) {
+	if j.Properties().On(false, j.getPropertyNames(jobPropertyDisable)...) || j.Properties().On(false, j.getPropertyNames(jobPropertyDisabled)...) {
 		ctx.Tracef("job disabled via properties")
 		return
 	}
@@ -461,11 +471,11 @@ func (j *Job) getPropertyNames(key string) []string {
 }
 
 func (j *Job) GetProperty(property string) (string, bool) {
-	if val := j.Context.Properties().String("jobs."+j.Name+"."+property, ""); val != "" {
+	if val := j.Context.Properties().String(strings.Join([]string{api.PropertyJobsPrefix + j.Name, property}, propertyNameSeparator), ""); val != "" {
 		return val, true
 	}
 	if j.ID != "" {
-		if val := j.Context.Properties().String(fmt.Sprintf("jobs.%s.%s.%s", j.Name, j.ID, property), ""); val != "" {
+		if val := j.Context.Properties().String(strings.Join([]string{api.PropertyJobsPrefix + j.Name, j.ID, property}, propertyNameSeparator), ""); val != "" {
 			return val, true
 		}
 	}
@@ -473,11 +483,11 @@ func (j *Job) GetProperty(property string) (string, bool) {
 }
 
 func (j *Job) GetPropertyInt(property string, def int) int {
-	if val := j.Context.Properties().Int("jobs."+j.Name+"."+property, def); val != def {
+	if val := j.Context.Properties().Int(strings.Join([]string{api.PropertyJobsPrefix + j.Name, property}, propertyNameSeparator), def); val != def {
 		return val
 	}
 	if j.ID != "" {
-		if val := j.Context.Properties().Int(fmt.Sprintf("jobs.%s.%s.%s", j.Name, j.ID, property), def); val != def {
+		if val := j.Context.Properties().Int(strings.Join([]string{api.PropertyJobsPrefix + j.Name, j.ID, property}, propertyNameSeparator), def); val != def {
 			return val
 		}
 	}
@@ -505,13 +515,13 @@ func (j *Job) init() error {
 		j.Timeout = duration
 	}
 
-	j.JobHistory = j.Properties().On(true, j.getPropertyNames("history")...)
+	j.JobHistory = j.Properties().On(true, j.getPropertyNames(jobPropertyHistory)...)
 	j.Retention.Success = j.GetPropertyInt("retention.success", j.Retention.Success)
 	j.Retention.Failed = j.GetPropertyInt("retention.failed", j.Retention.Failed)
 
-	j.Trace = j.Properties().On(false, j.getPropertyNames("trace")...)
-	j.Debug = j.Properties().On(false, j.getPropertyNames("debug")...)
-	j.Singleton = j.Properties().On(j.Singleton, j.getPropertyNames("singleton")...)
+	j.Trace = j.Properties().On(false, j.getPropertyNames(jobPropertyTrace)...)
+	j.Debug = j.Properties().On(false, j.getPropertyNames(jobPropertyDebug)...)
+	j.Singleton = j.Properties().On(j.Singleton, j.getPropertyNames(jobPropertySingleton)...)
 
 	// Set default retention if it is unset
 	if j.Retention.Empty() {

--- a/kubernetes/dynamic.go
+++ b/kubernetes/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"io"
 	"os"
 	"strings"
@@ -276,7 +277,7 @@ func (c *Client) GetRestMapper() (meta.RESTMapper, error) {
 	host = strings.ReplaceAll(host, "-", "_")
 	host = strings.ReplaceAll(host, ":", "_")
 	cacheDir := os.ExpandEnv("$HOME/.kube/cache/discovery/" + host)
-	timeout := properties.Duration(240*time.Minute, "kubernetes.cache.timeout")
+	timeout := properties.Duration(240*time.Minute, api.PropertyKubernetesCacheTimeout)
 	c.logger.V(3).Infof("creating new rest mapper with cache dir: %s and timeout: %s", cacheDir, timeout)
 	cache, err := disk.NewCachedDiscoveryClientForConfig(
 		c.Config,

--- a/leader/election.go
+++ b/leader/election.go
@@ -4,6 +4,7 @@ import (
 	gocontext "context"
 	"errors"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"log"
 	"os"
 	"strings"
@@ -99,7 +100,7 @@ func Register(
 	electionConfig := leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		ReleaseOnCancel: true,
-		LeaseDuration:   ctx.Properties().Duration("leader.lease.duration", 30*time.Second),
+		LeaseDuration:   ctx.Properties().Duration(api.PropertyLeaderLeaseDuration, 30*time.Second),
 		RenewDeadline:   15 * time.Second,
 		RetryPeriod:     5 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -26,7 +26,7 @@ import (
 func RunMigrations(pool *sql.DB, config api.Config) error {
 	l := logger.GetLogger("migrate")
 
-	if properties.On(false, "db.migrate.skip") {
+	if properties.On(false, api.PropertyDBMigrateSkip) {
 		return nil
 	}
 

--- a/query/config_cache.go
+++ b/query/config_cache.go
@@ -3,6 +3,7 @@ package query
 import (
 	"errors"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"math/rand/v2"
 	"time"
 
@@ -45,8 +46,8 @@ func randomDurationBetween(minDur, maxDur time.Duration) time.Duration {
 }
 
 func genConfigTraversalCacheExpiry() store.Option {
-	expiryWindowMin := properties.Duration(2*time.Hour, "config.traversal.cache_expiry.min")
-	expiryWindowMax := properties.Duration(4*time.Hour, "config.traversal.cache_expiry.max")
+	expiryWindowMin := properties.Duration(2*time.Hour, api.PropertyConfigTraversalCacheExpiryMin)
+	expiryWindowMax := properties.Duration(4*time.Hour, api.PropertyConfigTraversalCacheExpiryMax)
 	return store.WithExpiration(randomDurationBetween(expiryWindowMin, expiryWindowMax))
 }
 

--- a/query/query_logger.go
+++ b/query/query_logger.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"reflect"
 	"slices"
 	"strings"
@@ -72,7 +73,7 @@ type QueryTimer struct {
 
 func NewQueryLogger(ctx context.Context) QueryLogger {
 	l := ctx.Logger.V(3)
-	if ctx.Properties().On(false, "query.log") {
+	if ctx.Properties().On(false, api.PropertyQueryLog) {
 		l = ctx.Logger.V(0)
 	}
 	return QueryLogger{logger: l, queryLog: GetQueryLog(ctx)}

--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -367,7 +367,7 @@ func queryResourceSelector[T any](
 	}
 
 	queryLogger := ctx.Logger.V(3)
-	if ctx.Properties().On(false, "query.log") {
+	if ctx.Properties().On(false, api.PropertyQueryLog) {
 		queryLogger = ctx.Logger.V(0)
 	}
 
@@ -425,7 +425,7 @@ func queryResourceSelector[T any](
 		return nil, err
 	}
 
-	if ctx.Properties().String("log.level.resourceSelector", "") != "" {
+	if ctx.Properties().String(api.PropertyLogLevelResourceSelector, "") != "" {
 		ctx.WithName("resourceSelector").Logger.WithValues("cacheKey", cacheKey).Tracef("query: %s", query.ToSQL(func(tx *gorm.DB) *gorm.DB {
 			return tx.Find(&[]T{})
 		}))

--- a/query/topology.go
+++ b/query/topology.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"sort"
 	"strings"
 	"time"
@@ -243,7 +244,7 @@ func fetchAllComponents(ctx context.Context, params TopologyOptions) (TopologyRe
 
 	if !params.NoCache {
 		data, _ := json.Marshal(response)
-		topologyCache.Set(cacheKey, data, ctx.Properties().Duration("topology.cache.age", time.Minute*5))
+		topologyCache.Set(cacheKey, data, ctx.Properties().Duration(api.PropertyTopologyCacheAge, time.Minute*5))
 	}
 	return response, nil
 }
@@ -251,7 +252,7 @@ func fetchAllComponents(ctx context.Context, params TopologyOptions) (TopologyRe
 func Topology(ctx context.Context, params TopologyOptions) (*TopologyResponse, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel gocontext.CancelFunc
-		ctx, cancel = ctx.WithTimeout(ctx.Properties().Duration("topology.query.timeout", DefaultQueryTimeout))
+		ctx, cancel = ctx.WithTimeout(ctx.Properties().Duration(api.PropertyTopologyQueryTimeout, DefaultQueryTimeout))
 		defer cancel()
 	}
 	ctx, span := ctx.StartSpan("TopologyQuery")

--- a/rbac/enforcer.go
+++ b/rbac/enforcer.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flanksource/duty/api"
+
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
@@ -73,9 +75,9 @@ func Init(ctx context.Context, superUserIDs []string, adapters ...Adapter) error
 		ctx.Errorf("Failed to load existing policies: %v", err)
 	}
 
-	enforcer.SetExpireTime(ctx.Properties().Duration("casbin.cache.expiry", 1*time.Minute))
-	enforcer.EnableCache(ctx.Properties().On(true, "casbin.cache"))
-	if ctx.Properties().Int("casbin.log.level", 1) >= 2 {
+	enforcer.SetExpireTime(ctx.Properties().Duration(api.PropertyCasbinCacheExpiry, 1*time.Minute))
+	enforcer.EnableCache(ctx.Properties().On(true, api.PropertyCasbinCache))
+	if ctx.Properties().Int(api.PropertyCasbinLogLevel, 1) >= 2 {
 		enforcer.EnableLog(true)
 	}
 
@@ -93,7 +95,7 @@ func Init(ctx context.Context, superUserIDs []string, adapters ...Adapter) error
 		return fmt.Errorf("unable to load default policies: %v", err)
 	}
 
-	enforcer.EnableAutoSave(ctx.Properties().On(true, "casbin.auto.save"))
+	enforcer.EnableAutoSave(ctx.Properties().On(true, api.PropertyCasbinAutoSave))
 
 	// Adding policies in a loop is important
 	// If we use Enforcer.AddPolicies(), new policies do not get saved
@@ -110,7 +112,7 @@ func Init(ctx context.Context, superUserIDs []string, adapters ...Adapter) error
 		}
 	}
 
-	enforcer.StartAutoLoadPolicy(ctx.Properties().Duration("casbin.cache.reload.interval", 5*time.Minute))
+	enforcer.StartAutoLoadPolicy(ctx.Properties().Duration(api.PropertyCasbinCacheReloadInterval, 5*time.Minute))
 
 	return nil
 }
@@ -184,7 +186,7 @@ func Check(ctx context.Context, subject, object, action string) bool {
 		}
 	}
 
-	if ctx.Properties().On(false, "casbin.explain") {
+	if ctx.Properties().On(false, api.PropertyCasbinExplain) {
 		allowed, rules, err := enforcer.EnforceEx(subject, object, action)
 		if err != nil {
 			ctx.Errorf("failed run explained enforcer for user=%s, object=%s, action=%s: %v", subject, object, action, err)
@@ -226,7 +228,7 @@ func HasPermission(ctx context.Context, subject string, attr *models.ABACAttribu
 		return true
 	}
 
-	if ctx.Properties().On(false, "casbin.explain") {
+	if ctx.Properties().On(false, api.PropertyCasbinExplain) {
 		allowed, rules, err := enforcer.EnforceEx(subject, attr, action)
 		if err != nil {
 			ctx.Errorf("failed run explained enforcer for subject=%s, action=%s: %v", subject, action, err)

--- a/secret/keeper.go
+++ b/secret/keeper.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"sync"
 	"time"
 
@@ -66,7 +67,7 @@ func createOrGetKeeper(ctx context.Context) (*secrets.Keeper, error) {
 		return nil, err
 	}
 
-	ttl := ctx.Properties().Duration("secretkeeper.cache.ttl", defaultKeeperTTL)
+	ttl := ctx.Properties().Duration(api.PropertySecretKeeperCacheTTL, defaultKeeperTTL)
 	keeperCache.Set("keeper", keeper, ttl)
 	return keeper, nil
 }

--- a/shell/common.go
+++ b/shell/common.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	gocontext "context"
+	"github.com/flanksource/duty/api"
 	osExec "os/exec"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func JQ(ctx context.Context, path string, script string) (string, error) {
-	_ctx, cancel := gocontext.WithTimeout(ctx, properties.Duration(5*time.Second, "shell.jq.timeout"))
+	_ctx, cancel := gocontext.WithTimeout(ctx, properties.Duration(5*time.Second, api.PropertyShellJQTimeout))
 	defer cancel()
 
 	cmd := osExec.CommandContext(_ctx, "jq", script, path)
@@ -26,7 +27,7 @@ func JQ(ctx context.Context, path string, script string) (string, error) {
 }
 
 func YQ(ctx context.Context, path string, script string) (string, error) {
-	_ctx, cancel := gocontext.WithTimeout(ctx, properties.Duration(5*time.Second, "shell.yq.timeout", "shell.jq.timeout"))
+	_ctx, cancel := gocontext.WithTimeout(ctx, properties.Duration(5*time.Second, api.PropertyShellYQTimeout, api.PropertyShellJQTimeout))
 	defer cancel()
 
 	cmd := osExec.CommandContext(_ctx, "yq", script, path)

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"fmt"
+	"github.com/flanksource/duty/api"
 	"io"
 	"maps"
 	"os"
@@ -55,7 +56,7 @@ var allowedEnvVars = map[string]struct{}{
 }
 
 func init() {
-	for _, env := range strings.Split(properties.String("", "shell.allowed.envs"), ",") {
+	for _, env := range strings.Split(properties.String("", api.PropertyShellAllowedEnvs), ",") {
 		logger.V(5).Infof("allowing env var %s", env)
 		allowedEnvVars[env] = struct{}{}
 	}
@@ -166,7 +167,7 @@ func runPreparedCmd(ctx context.Context, exec Exec, cmd *osExec.Cmd, cmdCtx *com
 	} else {
 		ctx = ctx.WithLoggingValues("connection", setupResult)
 		defer func() {
-			if waitBeforeCleanup := ctx.Properties().Duration("shell.connection.wait_before_cleanup", 0); waitBeforeCleanup > 0 {
+			if waitBeforeCleanup := ctx.Properties().Duration(api.PropertyShellConnectionWaitBeforeCleanup, 0); waitBeforeCleanup > 0 {
 				time.Sleep(waitBeforeCleanup)
 			}
 			if err := setupResult.Cleanup(); err != nil {

--- a/tests/job_test.go
+++ b/tests/job_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/flanksource/duty/api"
 	"sync/atomic"
 	"time"
 
@@ -32,8 +33,8 @@ var _ = Describe("Job", Ordered, func() {
 		}
 		_ = context.UpdateProperty(ctx, "test.trace", "true")
 		_ = context.UpdateProperty(ctx, "test.db.level", "trace")
-		_ = context.UpdateProperty(ctx, "job.eviction.period", "1s")
-		_ = context.UpdateProperty(ctx, "job.jitter.disable", "true")
+		_ = context.UpdateProperty(ctx, api.PropertyJobEvictionPeriod, "1s")
+		_ = context.UpdateProperty(ctx, api.PropertyJobJitterDisable, "true")
 
 		sampleJob.Run()
 		Expect(sampleJob.Retention.Success).To(Equal(1))

--- a/tests/properties_registry_lint_test.go
+++ b/tests/properties_registry_lint_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestPropertyKeysDoNotUseStringLiterals(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	g.Expect(ok).To(gomega.BeTrue())
+	repoRoot := filepath.Dir(filepath.Dir(currentFile))
+
+	var violations []string
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "schema":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			keyArgs := propertyKeyArgs(call)
+			for _, arg := range keyArgs {
+				if containsStringLiteral(arg) {
+					pos := fset.Position(arg.Pos())
+					violations = append(violations, filepath.ToSlash(strings.TrimPrefix(pos.Filename, repoRoot+string(filepath.Separator)))+":"+itoa(pos.Line))
+				}
+			}
+			return true
+		})
+
+		return nil
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(violations).To(gomega.BeEmpty(), "property keys must use api.Property* constants, not string literals")
+}
+
+func propertyKeyArgs(call *ast.CallExpr) []ast.Expr {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !slices.Contains([]string{"Duration", "Int", "String", "On", "Off"}, selector.Sel.Name) {
+		return nil
+	}
+
+	if isCommonsPropertiesCall(selector) {
+		if len(call.Args) < 2 {
+			return nil
+		}
+		return call.Args[1:]
+	}
+
+	if isHierarchicalPropertiesCall(selector) {
+		switch selector.Sel.Name {
+		case "On":
+			if len(call.Args) < 2 {
+				return nil
+			}
+			return call.Args[1:]
+		default:
+			if len(call.Args) == 0 {
+				return nil
+			}
+			return call.Args[:1]
+		}
+	}
+
+	return nil
+}
+
+func isCommonsPropertiesCall(selector *ast.SelectorExpr) bool {
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && ident.Name == "properties"
+}
+
+func isHierarchicalPropertiesCall(selector *ast.SelectorExpr) bool {
+	call, ok := selector.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	innerSelector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && innerSelector.Sel.Name == "Properties"
+}
+
+func containsStringLiteral(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		lit, ok := n.(*ast.BasicLit)
+		if ok && lit.Kind == token.STRING {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	bp := len(b)
+	for i > 0 {
+		bp--
+		b[bp] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[bp:])
+}

--- a/tests/properties_test.go
+++ b/tests/properties_test.go
@@ -8,6 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	testPropertyInt      = "property1"
+	testPropertyDuration = "duration1"
+)
+
 var _ = Describe("Properties", Ordered, func() {
 	BeforeAll(func() {
 		Expect(DefaultContext.DB().Exec("TRUNCATE properties").Error).ToNot(HaveOccurred())
@@ -26,14 +31,14 @@ var _ = Describe("Properties", Ordered, func() {
 	})
 
 	It("Should default int values", func() {
-		Expect(DefaultContext.Properties().Int("property1", 10)).To(Equal(10))
-		Expect(context.UpdateProperty(DefaultContext, "property1", "20")).Error().ToNot(HaveOccurred())
-		Expect(DefaultContext.Properties().Int("property1", 10)).To(Equal(20))
+		Expect(DefaultContext.Properties().Int(testPropertyInt, 10)).To(Equal(10))
+		Expect(context.UpdateProperty(DefaultContext, testPropertyInt, "20")).Error().ToNot(HaveOccurred())
+		Expect(DefaultContext.Properties().Int(testPropertyInt, 10)).To(Equal(20))
 	})
 
 	It("Should default duration values", func() {
-		Expect(DefaultContext.Properties().Duration("duration1", 1*time.Minute)).To(Equal(1 * time.Minute))
-		Expect(context.UpdateProperty(DefaultContext, "duration1", "5m")).Error().ToNot(HaveOccurred())
-		Expect(DefaultContext.Properties().Duration("duration1", 1*time.Minute)).To(Equal(5 * time.Minute))
+		Expect(DefaultContext.Properties().Duration(testPropertyDuration, 1*time.Minute)).To(Equal(1 * time.Minute))
+		Expect(context.UpdateProperty(DefaultContext, testPropertyDuration, "5m")).Error().ToNot(HaveOccurred())
+		Expect(DefaultContext.Properties().Duration(testPropertyDuration, 1*time.Minute)).To(Equal(5 * time.Minute))
 	})
 })

--- a/upstream/client.go
+++ b/upstream/client.go
@@ -154,7 +154,7 @@ func (t *UpstreamClient) ListViews(ctx context.Context, views []ViewIdentifier) 
 		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	t.cache.Set(cacheKey, result, ctx.Properties().Duration("upstream.client.cache.view-columns.duration", gocache.DefaultExpiration))
+	t.cache.Set(cacheKey, result, ctx.Properties().Duration(api.PropertyUpstreamClientCacheViewColumns, gocache.DefaultExpiration))
 	return result, nil
 }
 

--- a/upstream/jobs.go
+++ b/upstream/jobs.go
@@ -78,7 +78,7 @@ func (fks ForeignKeyErrorSummary) MarshalJSON() ([]byte, error) {
 		return []byte(`null`), nil
 	}
 	// Display less IDs to keep UI consistent
-	idLimit := properties.Int(FKErrorIDCount, "upstream.summary.fkerror_id_count")
+	idLimit := properties.Int(FKErrorIDCount, api.PropertyUpstreamSummaryFKErrorIDCount)
 	fks.ids = lo.Slice(fks.ids, 0, idLimit)
 	if len(fks.ids) >= idLimit {
 		fks.ids = append(fks.ids, "...")
@@ -335,7 +335,7 @@ func reconcileTable(ctx context.Context, client *UpstreamClient, table pushableT
 
 		count += len(items)
 
-		batchSize := ctx.Properties().Int("update_is_pushed.batch.size", 200)
+		batchSize := ctx.Properties().Int(api.PropertyUpdateIsPushedBatchSize, 200)
 		for _, batch := range lo.Chunk(items, batchSize) {
 			backoff := retry.WithJitter(time.Second, retry.WithMaxRetries(3, retry.NewExponential(time.Second)))
 			err = retry.Do(ctx, backoff, func(_ctx gocontext.Context) error {
@@ -381,7 +381,7 @@ func reconcileTable(ctx context.Context, client *UpstreamClient, table pushableT
 }
 
 func ResetIsPushed(ctx context.Context) error {
-	intervalDays := ctx.Properties().Int("job.ResetIsPushed.interval_days", 7)
+	intervalDays := ctx.Properties().Int(api.PropertyJobResetIsPushedIntervalDays, 7)
 
 	defQuery := fmt.Sprintf(`created_at >= NOW() - INTERVAL '%d days' OR updated_at >= NOW() - INTERVAL '%d days'`, intervalDays, intervalDays)
 	overrides := map[string]string{
@@ -394,7 +394,7 @@ func ResetIsPushed(ctx context.Context) error {
 		models.ConfigItemLastScrapedTime{}.TableName(): defQuery, // We need default query without deleted_at
 	}
 
-	if !ctx.Properties().On(false, "job.ResetIsPushed.ignore_deleted_at") {
+	if !ctx.Properties().On(false, api.PropertyJobResetIsPushedIgnoreDeletedAt) {
 		defQuery += " AND deleted_at IS NULL"
 	}
 


### PR DESCRIPTION
Centralize duty property keys in `api/properties_registry.go` so property lookups can reference shared constants instead of ad-hoc string literals.

Replace existing property lookup strings with registry constants, including context/global property access.

Add `hack/propertylint` and wire it into `make lint` to prevent new string literals in `ctx.Properties()` and `properties.*` calls.