### PR TITLE
feat: add invites table

### DIFF
--- a/models/invites.go
+++ b/models/invites.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Invite struct {
+	ID         uuid.UUID  `json:"id" gorm:"default:generate_ulid()"`
+	Email      string     `json:"email"`
+	Role       string     `json:"role"`
+	InvitedAt  time.Time  `json:"invited_at" gorm:"default:now()"`
+	InvitedBy  *uuid.UUID `json:"invited_by,omitempty" gorm:"default:null"`
+	AcceptedAt *time.Time `json:"accepted_at,omitempty" gorm:"default:null"`
+}
+
+func (i Invite) TableName() string {
+	return "invites"
+}
+
+func (i Invite) PK() string {
+	return i.ID.String()
+}

--- a/rbac/objects.go
+++ b/rbac/objects.go
@@ -118,6 +118,7 @@ var dbResourceObjMap = map[string]string{
 	"incidents":                                 policy.ObjectIncident,
 	"integrations_with_status":                  policy.ObjectMonitor,
 	"integrations":                              policy.ObjectMonitor,
+	"invites":                                   policy.ObjectAuth,
 	"job_histories":                             policy.ObjectMonitor,
 	"job_history_latest_status":                 policy.ObjectMonitor,
 	"job_history_names":                         policy.ObjectMonitor,

--- a/schema/invites.hcl
+++ b/schema/invites.hcl
@@ -1,0 +1,54 @@
+table "invites" {
+  schema = schema.public
+  column "id" {
+    null    = false
+    type    = uuid
+    default = sql("generate_ulid()")
+  }
+  column "email" {
+    null = false
+    type = text
+  }
+  column "role" {
+    null = false
+    type = text
+  }
+  column "invited_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("now()")
+  }
+  column "invited_by" {
+    null = true
+    type = uuid
+  }
+  column "accepted_at" {
+    null    = true
+    type    = timestamptz
+    comment = "Used mainly to mark an invite as completed"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  index "invites_pending_email_unique_idx" {
+    unique = true
+    where  = "accepted_at IS NULL"
+    on {
+      expr = "lower(email)"
+    }
+  }
+  index "invites_email_idx" {
+    on {
+      expr = "lower(email)"
+    }
+  }
+  index "invites_invited_by_idx" {
+    columns = [column.invited_by]
+  }
+  foreign_key "invites_invited_by_fkey" {
+    columns     = [column.invited_by]
+    ref_columns = [table.people.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+}


### PR DESCRIPTION
Adds a dedicated `invites` table for auth invitations, including invited email, role, inviter, and lifecycle timestamps.

Pending invites are uniquely constrained by email until `accepted_at` is set, which marks the invite lifecycle as completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced user invitation system enabling email-based invitations with role assignment.
  * Invitations now record when they were sent, who sent them, and when they were accepted.
  * Enforced one pending invite per normalized email to prevent duplicate invites.
  * Added lookup and inviter relationship support in the database.

* **Bug Fixes / Security**
  * Updated authorization mappings to support invite-related access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->