### PR TITLE
fix: support deny scopes in RLS

### DIFF
--- a/rls/payload.go
+++ b/rls/payload.go
@@ -17,6 +17,7 @@ type Scope struct {
 	Agents []string          `json:"agents,omitempty"`
 	Names  []string          `json:"names,omitempty"`
 	ID     string            `json:"id,omitempty"`
+	Deny   bool              `json:"deny,omitempty"`
 }
 
 func (s Scope) IsEmpty() bool {
@@ -30,7 +31,7 @@ func (s Scope) Fingerprint() string {
 	slices.Sort(agentsCopy)
 	slices.Sort(namesCopy)
 
-	data := fmt.Sprintf("agents:%s | tags:%s | names:%s | id:%s", strings.Join(agentsCopy, "--"), tagSelectors, strings.Join(namesCopy, "--"), strings.TrimSpace(s.ID))
+	data := fmt.Sprintf("agents:%s | tags:%s | names:%s | id:%s | deny:%t", strings.Join(agentsCopy, "--"), tagSelectors, strings.Join(namesCopy, "--"), strings.TrimSpace(s.ID), s.Deny)
 	return fmt.Sprintf("scope::%s", hash.Sha256Hex(data))
 }
 

--- a/views/9998_rls_enable.sql
+++ b/views/9998_rls_enable.sql
@@ -1,6 +1,6 @@
 -- Generic function to match a row against an array of scopes
--- Returns TRUE if the row matches ANY scope in the array (OR logic between scopes)
--- Within a scope, ALL non-empty fields must match (AND logic within scope)
+-- Returns TRUE if the row matches ANY allow scope and no matching deny scope.
+-- Within a scope, ALL non-empty fields must match (AND logic within scope).
 CREATE OR REPLACE FUNCTION match_scope(
     scopes jsonb,           -- Array of scope objects from JWT claims
     row_tags jsonb,         -- The row's tags (can be NULL)
@@ -14,10 +14,12 @@ DECLARE
     scope_agents jsonb;
     scope_names jsonb;
     scope_id text;
+    scope_deny boolean;
     tags_match boolean;
     agents_match boolean;
     names_match boolean;
     id_match boolean;
+    allow_match boolean := FALSE;
 BEGIN
     -- If scopes is NULL or not an array or empty, deny access
     IF scopes IS NULL
@@ -26,7 +28,7 @@ BEGIN
         RETURN FALSE;
     END IF;
 
-    -- Iterate through each scope (OR logic between scopes)
+    -- Iterate through each scope (OR logic between allow scopes; any matching deny wins)
     FOR scope IN SELECT * FROM jsonb_array_elements(scopes)
     LOOP
         -- Extract fields from scope
@@ -34,6 +36,7 @@ BEGIN
         scope_agents := scope->'agents';
         scope_names := scope->'names';
         scope_id := NULLIF(btrim(scope->>'id'), '');
+        scope_deny := lower(coalesce(scope->>'deny', 'false')) = 'true';
 
         -- Check if scope has any fields applicable to this resource type
         -- A field is applicable if: scope defines it AND resource supports it (row param not NULL)
@@ -87,14 +90,16 @@ BEGIN
             id_match := lower(scope_id) = row_id::text;
         END IF;
 
-        -- If ALL conditions match (AND logic within scope), return TRUE
+        -- If ALL conditions match (AND logic within scope), apply effect
         IF tags_match AND agents_match AND names_match AND id_match THEN
-            RETURN TRUE;
+            IF scope_deny THEN
+                RETURN FALSE;
+            END IF;
+            allow_match := TRUE;
         END IF;
     END LOOP;
 
-    -- No scope matched
-    RETURN FALSE;
+    RETURN allow_match;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 


### PR DESCRIPTION
RLS payload scopes can now carry `deny: true`.\n\n`match_scope` now evaluates all matching scopes and rejects access when any matching scope is a deny, allowing explicit denies to override broader allow scopes without changing the payload shape or SQL function signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scopes now include a deny flag with allow-any, deny-wins matching semantics. Scope fingerprints have been updated to reflect the deny flag value, resulting in different fingerprints when the deny property changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->