### PR TITLE
fix(query): preserve negated catalog ID filters

### DIFF
--- a/query/catalog_search.go
+++ b/query/catalog_search.go
@@ -15,19 +15,19 @@ import (
 )
 
 type BaseCatalogSearch struct {
-	CatalogID             string `query:"id" json:"id"`
-	ConfigType            string `query:"config_type" json:"config_type"`
-	IncludeDeletedConfigs bool   `query:"include_deleted_configs" json:"include_deleted_configs"`
-	Depth                 int    `query:"depth" json:"depth"`
-	Tags                  string `query:"tags" json:"tags"`
-	AgentID               string `query:"agent_id" json:"agent_id"`
-	From                  string `query:"from" json:"from"`
-	To                    string `query:"to" json:"to"`
-	PageSize              int    `query:"page_size" json:"page_size"`
-	Page                  int    `query:"page" json:"page"`
-	SortBy                string `query:"sort_by" json:"sort_by"`
+	CatalogID             string                  `query:"id" json:"id"`
+	ConfigType            string                  `query:"config_type" json:"config_type"`
+	IncludeDeletedConfigs bool                    `query:"include_deleted_configs" json:"include_deleted_configs"`
+	Depth                 int                     `query:"depth" json:"depth"`
+	Tags                  string                  `query:"tags" json:"tags"`
+	AgentID               string                  `query:"agent_id" json:"agent_id"`
+	From                  string                  `query:"from" json:"from"`
+	To                    string                  `query:"to" json:"to"`
+	PageSize              int                     `query:"page_size" json:"page_size"`
+	Page                  int                     `query:"page" json:"page"`
+	SortBy                string                  `query:"sort_by" json:"sort_by"`
 	Recursive             ChangeRelationDirection `query:"recursive" json:"recursive"`
-	Soft                  bool   `query:"soft" json:"soft"`
+	Soft                  bool                    `query:"soft" json:"soft"`
 
 	// Lenient silently ignores invalid filters, inapplicable columns,
 	// and validation errors instead of returning errors.
@@ -121,6 +121,9 @@ func (b *BaseCatalogSearch) ResolveConfigIDs(ctx context.Context) ([]uuid.UUID, 
 		b.configIDs = ids
 		return ids, nil
 	}
+	if b.HasCatalogIDFilter() {
+		return nil, nil
+	}
 
 	response, err := SearchResources(ctx, SearchResourcesRequest{
 		Configs: []types.ResourceSelector{{Search: b.CatalogID, Cache: "no-cache"}},
@@ -140,6 +143,15 @@ func (b *BaseCatalogSearch) ResolveConfigIDs(ctx context.Context) ([]uuid.UUID, 
 
 func (b *BaseCatalogSearch) ConfigIDs() []uuid.UUID {
 	return b.configIDs
+}
+
+func (b *BaseCatalogSearch) HasCatalogIDFilter() bool {
+	for _, p := range strings.Split(b.CatalogID, ",") {
+		if strings.HasPrefix(strings.TrimSpace(p), "!") {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *BaseCatalogSearch) ApplyClauses(excludeColumns ...string) ([]clause.Expression, func(*gorm.DB) *gorm.DB, error) {

--- a/query/config_changes.go
+++ b/query/config_changes.go
@@ -222,7 +222,7 @@ func FindCatalogChanges(ctx context.Context, req CatalogChangesSearchRequest) (r
 	if err != nil {
 		return nil, err
 	}
-	if len(configIDs) == 0 && req.CatalogID != "" {
+	if len(configIDs) == 0 && req.CatalogID != "" && !req.HasCatalogIDFilter() {
 		return &CatalogChangesSearchResponse{}, nil
 	}
 

--- a/tests/config_changes_test.go
+++ b/tests/config_changes_test.go
@@ -322,6 +322,22 @@ var _ = ginkgo.Describe("Config changes recursive", ginkgo.Ordered, func() {
 			})
 		})
 
+		ginkgo.Context("Catalog id filter", func() {
+			ginkgo.It("supports NOT uuid", func() {
+				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{
+					BaseCatalogSearch: query.BaseCatalogSearch{
+						CatalogID: "!" + U.ID.String(),
+						SortBy:    "created_at",
+					},
+				})
+				Expect(err).To(BeNil())
+				Expect(response.Total).To(BeNumerically(">", 0))
+				for _, change := range response.Changes {
+					Expect(change.ConfigID).NotTo(Equal(U.ID.String()))
+				}
+			})
+		})
+
 		ginkgo.Context("Severity filter", func() {
 			ginkgo.It("NOT", func() {
 				response, err := query.FindCatalogChanges(DefaultContext, query.CatalogChangesSearchRequest{


### PR DESCRIPTION
Catalog changes requests can pass `id: "!uuid"` to exclude a config ID.

A catalog search refactor started resolving all non-UUID `id` values as resource selector queries, so negated UUIDs were sent to the selector grammar and failed to parse.

Skip resource selector resolution for negated catalog ID filters so catalog changes falls back to the existing `config_id` filtering path.

resolves: https://github.com/flanksource/flanksource-ui/issues/3006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negated catalog ID filters using the `!` prefix to exclude specific catalogs from search results, with improved query performance for filtered searches.

* **Tests**
  * Added test coverage for negated catalog ID filtering syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->