### PR TITLE
fix: add scraper ownership to config relationship conflicts

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -600,15 +600,11 @@ func (cs *ConfigScraper) BeforeCreate(tx *gorm.DB) error {
 }
 
 type ConfigRelationship struct {
-	ConfigID  string `json:"config_id" gorm:"primaryKey"`
-	RelatedID string `json:"related_id" gorm:"primaryKey"`
-	Relation  string `json:"relation" gorm:"primaryKey"`
-	// ScraperID identifies the scraper that owns this relationship and is part of the
-	// composite primary key. uuid.Nil represents a legacy / scraper-agnostic relationship
-	// from before scraper-ownership was introduced; new code should populate this from
-	// the active scraper context so multiple scrapers can independently maintain
-	// (related_id, config_id, relation) tuples without colliding.
-	ScraperID  uuid.UUID  `json:"scraper_id" gorm:"primaryKey"`
+	ConfigID  string `json:"config_id"`
+	RelatedID string `json:"related_id"`
+	Relation  string `json:"relation"`
+	// ScraperID identifies the scraper that owns this relationship.
+	ScraperID  *uuid.UUID `json:"scraper_id"`
 	SelectorID string     `json:"selector_id"`
 	CreatedAt  time.Time  `json:"created_at,omitempty"`
 	UpdatedAt  time.Time  `json:"updated_at,omitempty" gorm:"autoUpdateTime:false"`
@@ -636,12 +632,22 @@ func (t ConfigRelationship) UpdateParentsIsPushed(db *gorm.DB, items []DBTable) 
 }
 
 func (s ConfigRelationship) UpdateIsPushed(db *gorm.DB, items []DBTable) error {
-	ids := lo.Map(items, func(a DBTable, _ int) []string {
-		c := any(a).(ConfigRelationship)
-		return []string{c.RelatedID, c.ConfigID, c.Relation, c.ScraperID.String()}
-	})
-
-	return db.Model(&ConfigRelationship{}).Where("(related_id, config_id, relation, scraper_id) IN ?", ids).Update("is_pushed", true).Error
+	for _, item := range items {
+		c := any(item).(ConfigRelationship)
+		tx := db.Model(&ConfigRelationship{}).
+			Where("related_id = ?", c.RelatedID).
+			Where("config_id = ?", c.ConfigID).
+			Where("relation = ?", c.Relation)
+		if c.ScraperID == nil {
+			tx = tx.Where("scraper_id IS NULL")
+		} else {
+			tx = tx.Where("scraper_id = ?", *c.ScraperID)
+		}
+		if err := tx.Update("is_pushed", true).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (t ConfigRelationship) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
@@ -655,7 +661,7 @@ func (t ConfigRelationship) GetUnpushed(db *gorm.DB) ([]DBTable, error) {
 }
 
 func (cr ConfigRelationship) PK() string {
-	return cr.RelatedID + "," + cr.ConfigID + "," + cr.Relation + "," + cr.ScraperID.String()
+	return cr.RelatedID + "," + cr.ConfigID + "," + cr.Relation + "," + lo.FromPtr(cr.ScraperID).String()
 }
 
 func (cr ConfigRelationship) TableName() string {

--- a/schema/config.hcl
+++ b/schema/config.hcl
@@ -505,9 +505,8 @@ table "config_relationships" {
     type = text
   }
   column "scraper_id" {
-    null    = false
-    type    = uuid
-    default = "00000000-0000-0000-0000-000000000000"
+    null = true
+    type = uuid
   }
   column "created_at" {
     null    = false
@@ -543,6 +542,12 @@ table "config_relationships" {
     ref_columns = [table.config_items.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  foreign_key "config_relationships_scraper_id_fkey" {
+    columns     = [column.scraper_id]
+    ref_columns = [table.config_scrapers.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
   }
   index "config_relationships_related_id_config_id_relation_key" {
     unique  = true

--- a/tests/config_relationship_test.go
+++ b/tests/config_relationship_test.go
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("Config relationship Kubernetes", ginkgo.Ordered, func()
 		Expect(len(foundConfigs)).To(Equal(len(configItems)))
 
 		err = DefaultContext.DB().Model(models.ConfigRelationship{}).Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "related_id"}, {Name: "config_id"}, {Name: "relation"}, {Name: "scraper_id"}},
+			Columns:   models.ConfigRelationship{}.PKCols(),
 			DoNothing: true,
 		}).Create(&relationships).Error
 		Expect(err).To(BeNil())
@@ -432,16 +432,15 @@ var _ = ginkgo.Describe("Config relationship Kubernetes", ginkgo.Ordered, func()
 })
 
 // UpdateIsPushed matches rows by the 4-tuple (related_id, config_id, relation,
-// scraper_id). When ScraperID is uuid.Nil — the legacy / scraper-agnostic case
-// described on ConfigRelationship.ScraperID — the WHERE clause must still match
-// the inserted row. This regression test pushes one Nil-scraper relationship
-// and one real-scraper relationship, JSON round-trips them to simulate cross-
-// process delivery, and asserts both transition to is_pushed=true.
+// scraper_id). When ScraperID is nil, the WHERE clause must still match the
+// inserted row. This regression test pushes one nil-scraper relationship and one
+// real-scraper relationship, JSON round-trips them to simulate cross-process
+// delivery, and asserts both transition to is_pushed=true.
 var _ = ginkgo.Describe("config relationship UpdateIsPushed scraper round-trip", ginkgo.Ordered, func() {
 	var (
 		legacyRel models.ConfigRelationship
 		ownedRel  models.ConfigRelationship
-		scraperID = uuid.New()
+		scraperID = dummy.KubeScrapeConfig.ID
 	)
 
 	ginkgo.BeforeAll(func() {
@@ -455,7 +454,7 @@ var _ = ginkgo.Describe("config relationship UpdateIsPushed scraper round-trip",
 			ConfigID:  dummy.KubernetesCluster.ID.String(),
 			RelatedID: dummy.KubernetesNodeB.ID.String(),
 			Relation:  "scraper-roundtrip-owned",
-			ScraperID: scraperID,
+			ScraperID: &scraperID,
 		}
 		Expect(DefaultContext.DB().Create(&legacyRel).Error).To(BeNil())
 		Expect(DefaultContext.DB().Create(&ownedRel).Error).To(BeNil())
@@ -477,9 +476,9 @@ var _ = ginkgo.Describe("config relationship UpdateIsPushed scraper round-trip",
 		var roundtripped []models.ConfigRelationship
 		Expect(json.Unmarshal(raw, &roundtripped)).To(Succeed())
 		Expect(roundtripped).To(HaveLen(2))
-		// The Nil ScraperID must survive marshal/unmarshal as Nil, not get dropped.
-		Expect(roundtripped[0].ScraperID).To(Equal(uuid.Nil))
-		Expect(roundtripped[1].ScraperID).To(Equal(scraperID))
+		// The nil ScraperID must survive marshal/unmarshal as nil, not become uuid.Nil.
+		Expect(roundtripped[0].ScraperID).To(BeNil())
+		Expect(roundtripped[1].ScraperID).To(Equal(&scraperID))
 
 		items := lo.Map(roundtripped, func(r models.ConfigRelationship, _ int) models.DBTable { return r })
 		Expect(models.ConfigRelationship{}.UpdateIsPushed(DefaultContext.DB(), items)).To(Succeed())

--- a/tests/fixtures/dummy/all.go
+++ b/tests/fixtures/dummy/all.go
@@ -166,7 +166,7 @@ func (t *DummyData) Populate(ctx context.Context) error {
 		t.ConfigRelationships[i].UpdatedAt = createTime
 	}
 	if err := gormDB.Model(models.ConfigRelationship{}).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "related_id"}, {Name: "config_id"}, {Name: "relation"}, {Name: "scraper_id"}},
+		Columns:   models.ConfigRelationship{}.PKCols(),
 		DoNothing: true,
 	}).CreateInBatches(t.ConfigRelationships, 100).Error; err != nil {
 		return err

--- a/upstream/commands.go
+++ b/upstream/commands.go
@@ -67,8 +67,18 @@ func DeleteOnUpstream(ctx context.Context, req *PushData) error {
 	}
 
 	if len(req.ConfigRelationships) > 0 {
-		if err := db.Delete(req.ConfigRelationships).Error; err != nil {
-			return fmt.Errorf("error deleting config_relationships: %w", err)
+		for _, rel := range req.ConfigRelationships {
+			tx := db.Where("config_id = ?", rel.ConfigID).
+				Where("related_id = ?", rel.RelatedID).
+				Where("relation = ?", rel.Relation)
+			if rel.ScraperID == nil {
+				tx = tx.Where("scraper_id IS NULL")
+			} else {
+				tx = tx.Where("scraper_id = ?", *rel.ScraperID)
+			}
+			if err := tx.Delete(&models.ConfigRelationship{}).Error; err != nil {
+				return fmt.Errorf("error deleting config_relationships: %w", err)
+			}
 		}
 	}
 

--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -1078,8 +1078,8 @@ RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'INSERT' THEN
     IF NEW.parent_id IS NOT NULL THEN
-      INSERT INTO config_relationships (config_id, related_id, relation)
-      VALUES (NEW.parent_id, NEW.id, 'hard')
+      INSERT INTO config_relationships (config_id, related_id, relation, scraper_id)
+      VALUES (NEW.parent_id, NEW.id, 'hard', NEW.scraper_id)
       ON CONFLICT DO NOTHING;
     END IF;
   ELSIF TG_OP = 'UPDATE' THEN
@@ -1090,8 +1090,8 @@ BEGIN
       END IF;
 
       IF NEW.parent_id IS NOT NULL THEN
-        INSERT INTO config_relationships (config_id, related_id, relation)
-        VALUES (NEW.parent_id, NEW.id, 'hard')
+        INSERT INTO config_relationships (config_id, related_id, relation, scraper_id)
+        VALUES (NEW.parent_id, NEW.id, 'hard', NEW.scraper_id)
         ON CONFLICT DO NOTHING;
       END IF;
     END IF;
@@ -1155,7 +1155,7 @@ DECLARE
     v_config_item RECORD;
 BEGIN
     -- Get the config_item record
-    SELECT id, type, external_id
+    SELECT id, type, external_id, scraper_id
     INTO v_config_item
     FROM config_items
     WHERE id = config_item_id
@@ -1168,11 +1168,12 @@ BEGIN
 
     -- Only proceed if external_id array is not null and not empty
     IF v_config_item.external_id IS NOT NULL AND array_length(v_config_item.external_id, 1) > 0 THEN
-        INSERT INTO config_relationships (config_id, related_id, relation)
+        INSERT INTO config_relationships (config_id, related_id, relation, scraper_id)
         SELECT
             v_config_item.id as config_id,
             ci.id as related_id,
-            'Alias' as relation
+            'Alias' as relation,
+            v_config_item.scraper_id as scraper_id
         FROM config_items ci,
              unnest(v_config_item.external_id) as ext_id
         WHERE

--- a/views/028_config_relationship_populate.sql
+++ b/views/028_config_relationship_populate.sql
@@ -1,6 +1,10 @@
 -- Add the hard relationship for records existing before the trigger was added
-INSERT INTO config_relationships (config_id, related_id, relation)
-SELECT parent.id "config_id", child.id "related_id", 'hard'
+INSERT INTO config_relationships (config_id, related_id, relation, scraper_id)
+SELECT
+  parent.id "config_id",
+  child.id "related_id",
+  'hard',
+  child.scraper_id
 FROM config_items child
 JOIN config_items parent 
   ON child.parent_id = parent.id
@@ -12,4 +16,5 @@ WHERE child.deleted_at IS NULL
     WHERE cr.config_id = parent.id
       AND cr.related_id = child.id
       AND cr.relation = 'hard'
+      AND cr.scraper_id = child.scraper_id
   );


### PR DESCRIPTION
Config relationship upserts started conflicting with the existing unique index, which includes `scraper_id`.

Update the schema and model conflict columns to include `scraper_id`, remove the legacy default, and add a FK to `config_scrapers`.
Keep `scraper_id` nullable for this rollout so existing rows with null ownership do not block migration; follow-up can backfill and enforce NOT NULL.

Also update relationship-generating SQL to explicitly carry scraper ownership into inserted relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added materialized views for 3-day, 7-day, and 30-day config change summaries.
  * Introduced recursive config relationship lookup and path analysis functions.

* **Enhancements**
  * Improved config relationship tracking with scraper identification.
  * Updated database schema for enhanced relationship integrity and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->