### PR TITLE
feat: move config change dedupe into duty

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -712,10 +712,10 @@ type ConfigChange struct {
 	Patches string `gorm:"column:patches;default:null" json:"patches,omitempty"`
 
 	// Diff represents the differences introduced by this change.
-	Diff string `gorm:"column:diff;default:null" json:"diff,omitempty"`
+	Diff *string `gorm:"column:diff;default:null" json:"diff,omitempty"`
 
 	// Fingerprint is a uniquest identifier for the change, it ignores all UUID, numbers and timestamps to enable de-duplication of equivalent changes.
-	Fingerprint string `gorm:"column:fingerprint;default:null" json:"fingerprint,omitempty"`
+	Fingerprint *string `gorm:"column:fingerprint;default:null" json:"fingerprint,omitempty"`
 
 	// Details contains additional information about the change in JSON format.
 	Details types.JSON `json:"details,omitempty"`
@@ -820,16 +820,16 @@ func (c ConfigChange) RowDetail() api.Textable {
 	if c.ExternalChangeID != nil && *c.ExternalChangeID != "" {
 		t = t.Append("ExternalChangeID: ", "text-gray-500 font-medium").Append(*c.ExternalChangeID)
 	}
-	if c.Fingerprint != "" {
-		t = t.NewLine().Append("Fingerprint: ", "text-gray-500 font-medium").Append(c.Fingerprint)
+	if c.Fingerprint != nil && *c.Fingerprint != "" {
+		t = t.NewLine().Append("Fingerprint: ", "text-gray-500 font-medium").Append(*c.Fingerprint)
 	}
 	if len(c.Details) > 0 {
 		data, _ := json.MarshalIndent(c.Details, "", "  ")
 		t = t.NewLine().Append(clicky.CodeBlock("json", string(data)))
 	}
-	if c.Diff != "" {
+	if c.Diff != nil && *c.Diff != "" {
 		t = t.NewLine().Append("Diff: ", "text-gray-500 font-medium")
-		t = t.NewLine().Append(clicky.CodeBlock("diff", c.Diff))
+		t = t.NewLine().Append(clicky.CodeBlock("diff", *c.Diff))
 	}
 	if c.Patches != "" {
 		t = t.NewLine().Append("Patches: ", "text-gray-500 font-medium")

--- a/models/config_change_dedupe.go
+++ b/models/config_change_dedupe.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"gorm.io/gorm"
+)
+
+// ConfigChangeUpdate represents an existing config change that should be updated
+// instead of inserting a duplicate.
+type ConfigChangeUpdate struct {
+	Change         *ConfigChange
+	CountIncrement int
+	FirstInBatch   bool // First occurrence in current batch (not found in cache)
+}
+
+var ChangeCacheByFingerprint = cache.New(time.Hour, time.Hour)
+
+func ChangeFingerprintCacheKey(configID, fingerprint string) string {
+	return fmt.Sprintf("%s:%s", configID, fingerprint)
+}
+
+func InitChangeFingerprintCache(db *gorm.DB, window time.Duration) error {
+	type configChangeFingerprint struct {
+		ID          string
+		ConfigID    string
+		Fingerprint string
+		CreatedAt   time.Time
+	}
+
+	var changes []configChangeFingerprint
+	if err := db.Table("config_changes").
+		Select("id, config_id, fingerprint, created_at").
+		Where("fingerprint IS NOT NULL").
+		Where(fmt.Sprintf("created_at >= NOW() - INTERVAL '%d SECOND'", int(window.Seconds()))).
+		Find(&changes).Error; err != nil {
+		return err
+	}
+
+	for _, c := range changes {
+		if c.Fingerprint == "" {
+			continue
+		}
+
+		key := ChangeFingerprintCacheKey(c.ConfigID, c.Fingerprint)
+		ChangeCacheByFingerprint.Set(key, c.ID, time.Until(c.CreatedAt.Add(window)))
+	}
+
+	return nil
+}
+
+// DedupConfigChanges deduplicates config changes by (config_id, fingerprint).
+// New fingerprints are returned in nonDuped for insertion; fingerprints already
+// present in the cache are returned as updates with CountIncrement.
+func DedupConfigChanges(window time.Duration, changes []*ConfigChange) ([]*ConfigChange, []ConfigChangeUpdate) {
+	if len(changes) == 0 {
+		return nil, nil
+	}
+
+	var nonDuped []*ConfigChange
+	fingerprinted := map[string]ConfigChangeUpdate{}
+
+	for _, change := range changes {
+		if change.Fingerprint == nil || *change.Fingerprint == "" {
+			nonDuped = append(nonDuped, change)
+			continue
+		}
+
+		key := ChangeFingerprintCacheKey(change.ConfigID, *change.Fingerprint)
+		if existingChangeID, ok := ChangeCacheByFingerprint.Get(key); !ok {
+			ChangeCacheByFingerprint.Set(key, change.ID, window)
+			fingerprinted[change.ID] = ConfigChangeUpdate{Change: change, CountIncrement: 0, FirstInBatch: true}
+		} else {
+			change.ID = existingChangeID.(string)
+			ChangeCacheByFingerprint.Set(key, change.ID, window) // Refresh the cache expiry
+
+			if existing, ok := fingerprinted[change.ID]; ok {
+				// Preserve the original change, just increment the count
+				fingerprinted[change.ID] = ConfigChangeUpdate{
+					Change:         existing.Change,
+					CountIncrement: existing.CountIncrement + 1,
+					FirstInBatch:   existing.FirstInBatch,
+				}
+			} else {
+				fingerprinted[change.ID] = ConfigChangeUpdate{Change: change, CountIncrement: 1, FirstInBatch: false}
+			}
+		}
+	}
+
+	var deduped []ConfigChangeUpdate
+	for _, v := range fingerprinted {
+		if v.FirstInBatch || v.CountIncrement == 0 {
+			// First occurrence in the batch will be inserted
+			nonDuped = append(nonDuped, v.Change)
+		} else {
+			deduped = append(deduped, v)
+		}
+	}
+
+	return nonDuped, deduped
+}

--- a/models/config_change_dedupe_test.go
+++ b/models/config_change_dedupe_test.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+func TestDedupConfigChanges(t *testing.T) {
+	configID := "dae6b3f5-bc26-48ac-8ad4-06e5efbb2a7d"
+	abcKey := ChangeFingerprintCacheKey(configID, "abc")
+	ChangeCacheByFingerprint.Set(abcKey, "8b9d2659-7a11-46ff-bdff-1c4e8964c437", time.Hour)
+	defer func() {
+		ChangeCacheByFingerprint.Delete(abcKey)
+		ChangeCacheByFingerprint.Delete(ChangeFingerprintCacheKey(configID, "xyz"))
+	}()
+
+	changes := []*ConfigChange{
+		{ID: "8b9d2659-7a11-46ff-bdff-1c4e8964c437", Fingerprint: lo.ToPtr("abc"), ConfigID: configID, Summary: "first", Count: 1},
+		{ID: "new-1", Fingerprint: lo.ToPtr("abc"), ConfigID: configID, Summary: "second", Count: 1},
+		{ID: "new-2", Fingerprint: lo.ToPtr("abc"), ConfigID: configID, Summary: "third", Count: 1},
+		{ID: "01eda583-3f5e-4c44-851f-93ac73272b92", Fingerprint: lo.ToPtr("xyz"), ConfigID: configID, Summary: "different", Count: 1},
+		{ID: "new-3", Fingerprint: lo.ToPtr("xyz"), ConfigID: configID, Summary: "different two", Count: 1},
+	}
+
+	nonDuped, deduped := DedupConfigChanges(time.Hour, changes)
+
+	if len(nonDuped) != 1 || nonDuped[0].ID != "01eda583-3f5e-4c44-851f-93ac73272b92" {
+		t.Fatalf("expected one non-duplicate xyz change, got %#v", nonDuped)
+	}
+
+	if len(deduped) != 1 {
+		t.Fatalf("expected one deduped change, got %#v", deduped)
+	}
+	if deduped[0].Change.ID != "8b9d2659-7a11-46ff-bdff-1c4e8964c437" {
+		t.Fatalf("expected existing change id, got %s", deduped[0].Change.ID)
+	}
+	if deduped[0].CountIncrement != 3 {
+		t.Fatalf("expected count increment 3, got %d", deduped[0].CountIncrement)
+	}
+}


### PR DESCRIPTION
Config-db performs in-app config change deduplication based on fingerprint and dedupe window before inserting changes.

Move that here, in duty, so mission-control plugins can use the same function to insert changes for plugin invocation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced deduplication mechanism for configuration changes to eliminate duplicate records based on fingerprint matching.
  * Made fingerprint and diff fields optional for improved data consistency.

* **Performance**
  * Implemented in-memory fingerprint caching to streamline configuration change tracking and reduce redundant operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/duty/pull/1971)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->