### PR TITLE
test(query): cover connection resource selectors

### DIFF
--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -327,6 +327,13 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 			Connections: []models.Connection{dummy.AWSConnection},
 		},
 		{
+			description: "connection by name",
+			query: query.SearchResourcesRequest{
+				Connections: []types.ResourceSelector{{Name: dummy.PostgresConnection.Name}},
+			},
+			Connections: []models.Connection{dummy.PostgresConnection},
+		},
+		{
 			description: "connection by type",
 			query: query.SearchResourcesRequest{
 				Connections: []types.ResourceSelector{{Types: []string{dummy.AWSConnection.Type}}},
@@ -456,6 +463,8 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 				Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Components...)), "should contain components")
 				Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Checks...)), "should contain checks")
 				Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.ConfigChanges...)), "should contain config changes")
+				Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Playbooks...)), "should contain playbooks")
+				Expect(items.GetIDs()).To(ContainElements(models.GetIDs(test.Connections...)), "should contain connections")
 			})
 		}
 	})


### PR DESCRIPTION
Connection selector cases existed in the shared resource selector tests, but their expected IDs were not asserted.

Add assertion coverage for connection results in the main loop and include a name-based connection selector case so regressions are caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now include connections and playbooks alongside existing resource types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/duty/pull/1974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->