### PR TITLE
feat: Support for postgREST JWT Audience.

### DIFF
--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -41,7 +41,7 @@ indirection:
 | Env var | Purpose |
 | --- | --- |
 | `DB_URL` | Default value for `--db` if `--db` is not set. |
-| `PGRST_JWT_SECRET` | Default value for `--postgrest-jwt-secret` if the flag is not set. |
+| `PGRST_JWT_SECRET` | Default value for `--postgrest-jwt-secret` if the flag is not set. Despite the name, PostgREST accepts either an HMAC secret or a public JWK/JWKS for asymmetric JWT verification. |
 | `PGRST_VERSION` | Overrides the bundled PostgREST version. |
 | `PGRST_ARCH` | Overrides the PostgREST binary architecture. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Default OpenTelemetry collector endpoint. |
@@ -155,7 +155,7 @@ These are not runtime properties, but they are the main Duty startup settings:
 | `--db-schema` | `public` | PostgreSQL schema. |
 | `--postgrest-uri` | `http://localhost:3000` | Localhost starts an embedded PostgREST process. Empty disables PostgREST. |
 | `--postgrest-log-level` | `info` | PostgREST log level. |
-| `--postgrest-jwt-secret` | `PGRST_JWT_SECRET` | JWT secret. The default is resolved from `PGRST_JWT_SECRET`. |
+| `--postgrest-jwt-secret` | `PGRST_JWT_SECRET` | PostgREST JWT verification material. Can be an HMAC secret for symmetric algorithms, or a public JWK/JWKS for asymmetric algorithms. The default is resolved from `PGRST_JWT_SECRET`. |
 | `--disable-postgrest` | varies | Deprecated; use `--postgrest-uri ''`. |
 | `--postgrest-role` | `postgrest_api` | Authenticated PostgREST database role. |
 | `--postgrest-anon-role` | `postgrest_anon` | Unauthenticated PostgREST database role. |

--- a/api/config.go
+++ b/api/config.go
@@ -122,13 +122,20 @@ func (c Config) GetUsername() string {
 }
 
 type PostgrestConfig struct {
-	Port       int
-	Disable    bool
-	LogLevel   string
-	URL        string
-	Version    string
-	Arch       string
-	JWTSecret  string
+	Port     int
+	Disable  bool
+	LogLevel string
+	URL      string
+	Version  string
+	Arch     string
+
+	// JWTSecret is the PostgREST jwt-secret verification material.
+	// It can be an HMAC secret for symmetric algorithms, or a public JWK/JWKS for asymmetric algorithms.
+	JWTSecret string
+
+	// JWTAud is the PostgREST jwt-aud value used to validate the JWT aud claim.
+	JWTAud string
+
 	DBRole     string
 	AnonDBRole string
 	AdminPort  int
@@ -157,9 +164,10 @@ func (p PostgrestConfig) ReadEnv() PostgrestConfig {
 }
 
 func (p PostgrestConfig) String() string {
-	return fmt.Sprintf("version:%v port=%d log-level=%v, jwt=%s",
+	return fmt.Sprintf("version:%v port=%d log-level=%v, jwt=%s aud=%s",
 		p.Version,
 		p.Port,
 		p.LogLevel,
-		logger.PrintableSecret(p.JWTSecret))
+		logger.PrintableSecret(p.JWTSecret),
+		p.JWTAud)
 }

--- a/postgrest/postgrest.go
+++ b/postgrest/postgrest.go
@@ -37,6 +37,7 @@ func runBinary(config api.Config, msg string, args ...any) error {
 		"PGRST_LOG_LEVEL":                config.Postgrest.LogLevel,
 		"PGRST_DB_MAX_ROWS":              strconv.Itoa(config.Postgrest.MaxRows),
 		"PGRST_JWT_SECRET":               config.Postgrest.JWTSecret,
+		"PGRST_JWT_AUD":                  config.Postgrest.JWTAud,
 	}
 
 	return exec.ExecfWithEnv(bin+" "+msg, env, args...)

--- a/start.go
+++ b/start.go
@@ -119,6 +119,18 @@ var KratosAuth = func(config api.Config) api.Config {
 	return config
 }
 
+func IsEmbeddedPostgREST(config api.PostgrestConfig) bool {
+	if config.URL == "" || config.Disable {
+		return false
+	}
+
+	parsed, err := url.Parse(config.URL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Hostname(), "localhost")
+}
+
 func Start(name string, opts ...StartOption) (context.Context, func(), error) {
 	config := api.DefaultConfig
 	for _, opt := range opts {
@@ -141,16 +153,14 @@ func Start(name string, opts ...StartOption) (context.Context, func(), error) {
 		api.DefaultConfig.ConnectionString = embeddedDBConnectionString
 	}
 
-	if config.Postgrest.URL != "" && !config.Postgrest.Disable {
-		if configured, startLocal, err := configurePostgrest(config); err != nil {
-			return context.Context{}, nil, err
-		} else {
-			config = configured
-			if startLocal {
-				go postgrest.Start(config)
-			}
-			api.DefaultConfig = config
+	if configured, err := configurePostgrest(config); err != nil {
+		return context.Context{}, nil, err
+	} else {
+		config = configured
+		if IsEmbeddedPostgREST(config.Postgrest) {
+			go postgrest.Start(config)
 		}
+		api.DefaultConfig = config
 	}
 
 	var ctx context.Context
@@ -193,22 +203,21 @@ func Start(name string, opts ...StartOption) (context.Context, func(), error) {
 	return ctx, stop, nil
 }
 
-func configurePostgrest(config api.Config) (api.Config, bool, error) {
+func configurePostgrest(config api.Config) (api.Config, error) {
 	if config.Postgrest.URL == "" || config.Postgrest.Disable {
-		return config, false, nil
+		return config, nil
 	}
 
 	parsedURL, err := url.Parse(config.Postgrest.URL)
 	if err != nil {
-		return config, false, fmt.Errorf("failed to parse PostgREST URL: %v", err)
+		return config, fmt.Errorf("failed to parse PostgREST URL: %v", err)
 	}
 
-	host := strings.ToLower(parsedURL.Hostname())
 	port, _ := strconv.Atoi(parsedURL.Port())
 	config.Postgrest.Port = port
 
-	if host != "localhost" {
-		return config, false, nil
+	if !IsEmbeddedPostgREST(config.Postgrest) {
+		return config, nil
 	}
 
 	if config.Postgrest.Port == 0 {
@@ -221,7 +230,7 @@ func configurePostgrest(config api.Config) (api.Config, bool, error) {
 		logger.Warnf("PostgREST JWT secret not specified, generating random secret")
 		config.Postgrest.JWTSecret = utils.RandomString(32)
 	}
-	return config, true, nil
+	return config, nil
 }
 
 const posmasterLinePort = 3

--- a/start_test.go
+++ b/start_test.go
@@ -18,10 +18,10 @@ var _ = ginkgo.Describe("PostgREST configuration", func() {
 			},
 		}
 
-		configured, startLocal, err := configurePostgrest(config)
+		configured, err := configurePostgrest(config)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(startLocal).To(BeTrue())
+		Expect(IsEmbeddedPostgREST(configured.Postgrest)).To(BeTrue())
 		Expect(configured.Postgrest.Port).To(BeNumerically(">", 0))
 		Expect(configured.Postgrest.URL).ToNot(Equal("http://localhost:0"))
 
@@ -39,10 +39,10 @@ var _ = ginkgo.Describe("PostgREST configuration", func() {
 			},
 		}
 
-		configured, startLocal, err := configurePostgrest(config)
+		configured, err := configurePostgrest(config)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(startLocal).To(BeTrue())
+		Expect(IsEmbeddedPostgREST(configured.Postgrest)).To(BeTrue())
 		Expect(configured.Postgrest.Port).To(Equal(3000))
 		Expect(configured.Postgrest.URL).To(Equal("http://localhost:3000"))
 	})
@@ -54,10 +54,10 @@ var _ = ginkgo.Describe("PostgREST configuration", func() {
 			},
 		}
 
-		configured, startLocal, err := configurePostgrest(config)
+		configured, err := configurePostgrest(config)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(startLocal).To(BeFalse())
+		Expect(IsEmbeddedPostgREST(configured.Postgrest)).To(BeFalse())
 		Expect(configured.Postgrest.Port).To(Equal(3000))
 		Expect(configured.Postgrest.URL).To(Equal("http://postgrest.default.svc:3000"))
 	})
@@ -70,10 +70,10 @@ var _ = ginkgo.Describe("PostgREST configuration", func() {
 			},
 		}
 
-		configured, startLocal, err := configurePostgrest(config)
+		configured, err := configurePostgrest(config)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(startLocal).To(BeFalse())
+		Expect(IsEmbeddedPostgREST(configured.Postgrest)).To(BeFalse())
 		Expect(configured.Postgrest.Port).To(Equal(0))
 		Expect(configured.Postgrest.URL).To(Equal("http://localhost:0"))
 	})


### PR DESCRIPTION
We'll migrate mission-control to use assymetric key for postgREST JWT

https://docs.postgrest.org/en/v14/references/auth.html#asymmetric-keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified JWT config to state PostgREST accepts HMAC secrets or public JWK/JWKS material.

* **New Features**
  * Added JWT audience (aud) claim validation and propagation to launched PostgREST.

* **Bug Fixes / Behavior**
  * Embedded PostgREST will only be started when configured to target localhost, avoiding unintended remote starts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/duty/pull/1987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->