### PR TITLE
fix: drop event enqueue trigger on checks table

### DIFF
--- a/views/000_drop.sql
+++ b/views/000_drop.sql
@@ -1,6 +1,7 @@
 DROP TRIGGER IF EXISTS check_statuses_change_to_event_queue ON check_statuses;
 DROP TRIGGER IF EXISTS notification_update_enqueue ON notifications;
 DROP FUNCTION IF EXISTS notifications_trigger_function();
+DROP TRIGGER IF EXISTS check_enqueue ON checks;
 
 CREATE OR REPLACE FUNCTION drop_push_queue_triggers () returns void as $$
 DECLARE


### PR DESCRIPTION
Fixes: https://github.com/flanksource/canary-checker/issues/2977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration script to remove an obsolete database trigger during the cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->