### PR TITLE
fix(connection): template HTTP connection fields

### DIFF
--- a/connection/aws.go
+++ b/connection/aws.go
@@ -18,13 +18,13 @@ import (
 // +kubebuilder:object:generate=true
 type AWSConnection struct {
 	// ConnectionName of the connection. It'll be used to populate the endpoint, accessKey and secretKey.
-	ConnectionName string       `yaml:"connection,omitempty" json:"connection,omitempty"`
-	AccessKey      types.EnvVar `yaml:"accessKey,omitempty" json:"accessKey,omitempty"`
-	SecretKey      types.EnvVar `yaml:"secretKey,omitempty" json:"secretKey,omitempty"`
-	SessionToken   types.EnvVar `yaml:"sessionToken,omitempty" json:"sessionToken,omitempty"`
-	AssumeRole     string       `yaml:"assumeRole,omitempty" json:"assumeRole,omitempty"`
-	Region         string       `yaml:"region,omitempty" json:"region,omitempty"`
-	Endpoint       string       `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	ConnectionName string       `yaml:"connection,omitempty" json:"connection,omitempty" template:"true"`
+	AccessKey      types.EnvVar `yaml:"accessKey,omitempty" json:"accessKey,omitempty" template:"true"`
+	SecretKey      types.EnvVar `yaml:"secretKey,omitempty" json:"secretKey,omitempty" template:"true"`
+	SessionToken   types.EnvVar `yaml:"sessionToken,omitempty" json:"sessionToken,omitempty" template:"true"`
+	AssumeRole     string       `yaml:"assumeRole,omitempty" json:"assumeRole,omitempty" template:"true"`
+	Region         string       `yaml:"region,omitempty" json:"region,omitempty" template:"true"`
+	Endpoint       string       `yaml:"endpoint,omitempty" json:"endpoint,omitempty" template:"true"`
 	// Skip TLS verify when connecting to aws
 	SkipTLSVerify bool `yaml:"skipTLSVerify,omitempty" json:"skipTLSVerify,omitempty"`
 }

--- a/connection/http.go
+++ b/connection/http.go
@@ -32,11 +32,11 @@ type TLSConfig struct {
 	// HandshakeTimeout defaults to 10 seconds
 	HandshakeTimeout time.Duration `json:"handshakeTimeout,omitempty" yaml:"handshakeTimeout,omitempty"`
 	// PEM encoded certificate of the CA to verify the server certificate
-	CA types.EnvVar `json:"ca,omitempty" yaml:"ca,omitempty"`
+	CA types.EnvVar `json:"ca,omitempty" yaml:"ca,omitempty" template:"true"`
 	// PEM encoded client certificate
-	Cert types.EnvVar `json:"cert,omitempty" yaml:"cert,omitempty"`
+	Cert types.EnvVar `json:"cert,omitempty" yaml:"cert,omitempty" template:"true"`
 	// PEM encoded client private key
-	Key types.EnvVar `json:"key,omitempty" yaml:"key,omitempty"`
+	Key types.EnvVar `json:"key,omitempty" yaml:"key,omitempty" template:"true"`
 }
 
 func (t TLSConfig) IsEmpty() bool {
@@ -80,8 +80,8 @@ func (t TLSConfig) clientConfig() (*tls.Config, error) {
 
 // +kubebuilder:object:generate=true
 type AWSSigV4 struct {
-	AWSConnection `json:",inline" yaml:",inline"`
-	Service       string `json:"service,omitempty" yaml:"service,omitempty"`
+	AWSConnection `json:",inline" yaml:",inline" template:"true"`
+	Service       string `json:"service,omitempty" yaml:"service,omitempty" template:"true"`
 }
 
 // cachedAWSConfig wraps aws.Config with DeepCopy methods so controller-gen
@@ -100,14 +100,14 @@ func (in *cachedAWSConfig) DeepCopy() *cachedAWSConfig {
 
 // +kubebuilder:object:generate=true
 type HTTPConnection struct {
-	ConnectionName      string `json:"connection,omitempty" yaml:"connection,omitempty"`
-	types.HTTPBasicAuth `json:",inline"`
-	URL                 string         `json:"url,omitempty" yaml:"url,omitempty"`
-	Bearer              types.EnvVar   `json:"bearer,omitempty" yaml:"bearer,omitempty"`
-	OAuth               types.OAuth    `json:"oauth,omitempty" yaml:"oauth,omitempty"`
-	TLS                 TLSConfig      `json:"tls,omitempty" yaml:"tls,omitempty"`
-	Headers             []types.EnvVar `json:"headers,omitempty" yaml:"headers,omitempty"`
-	AWSSigV4            *AWSSigV4      `json:"awsSigV4,omitempty" yaml:"awsSigV4,omitempty"`
+	ConnectionName      string `json:"connection,omitempty" yaml:"connection,omitempty" template:"true"`
+	types.HTTPBasicAuth `json:",inline" template:"true"`
+	URL                 string         `json:"url,omitempty" yaml:"url,omitempty" template:"true"`
+	Bearer              types.EnvVar   `json:"bearer,omitempty" yaml:"bearer,omitempty" template:"true"`
+	OAuth               types.OAuth    `json:"oauth,omitempty" yaml:"oauth,omitempty" template:"true"`
+	TLS                 TLSConfig      `json:"tls,omitempty" yaml:"tls,omitempty" template:"true"`
+	Headers             []types.EnvVar `json:"headers,omitempty" yaml:"headers,omitempty" template:"true"`
+	AWSSigV4            *AWSSigV4      `json:"awsSigV4,omitempty" yaml:"awsSigV4,omitempty" template:"true"`
 
 	// Exported to avoid being flagged by CRD unexported-field validation.
 	// The underlying type is unexported, so external code cannot construct values.

--- a/connection/http_test.go
+++ b/connection/http_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
 	"github.com/onsi/gomega"
@@ -175,6 +176,91 @@ func TestCreateHTTPClientWithTLS(t *testing.T) {
 	client, err := CreateHTTPClient(nil, HTTPConnection{TLS: TLSConfig{InsecureSkipVerify: true}})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(client).ToNot(gomega.BeNil())
+}
+
+func TestHTTPConnectionTemplatesFields(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := dutyContext.New()
+	conn := HTTPConnection{
+		ConnectionName: "connection://$(.params.connection)",
+		HTTPBasicAuth: types.HTTPBasicAuth{Authentication: types.Authentication{
+			Username: types.EnvVar{ValueStatic: "$(.params.username)"},
+			Password: types.EnvVar{ValueStatic: "$(.params.password)"},
+		}},
+		URL:    "$(.params.url)",
+		Bearer: types.EnvVar{ValueStatic: "$(.params.bearer)"},
+		OAuth: types.OAuth{
+			ClientID:     types.EnvVar{ValueStatic: "$(.params.clientID)"},
+			ClientSecret: types.EnvVar{ValueStatic: "$(.params.clientSecret)"},
+			TokenURL:     "$(.params.tokenURL)",
+			Scopes:       []string{"$(.params.scope)"},
+			Params:       map[string]string{"audience": "$(.params.audience)"},
+		},
+		TLS: TLSConfig{
+			CA:   types.EnvVar{ValueStatic: "$(.params.ca)"},
+			Cert: types.EnvVar{ValueStatic: "$(.params.cert)"},
+			Key:  types.EnvVar{ValueStatic: "$(.params.key)"},
+		},
+		Headers: []types.EnvVar{{Name: "Content-Type", ValueStatic: "$(.params.contentType)"}},
+		AWSSigV4: &AWSSigV4{
+			AWSConnection: AWSConnection{
+				AccessKey:    types.EnvVar{ValueStatic: "$(.params.accessKey)"},
+				SecretKey:    types.EnvVar{ValueStatic: "$(.params.secretKey)"},
+				SessionToken: types.EnvVar{ValueStatic: "$(.params.sessionToken)"},
+				AssumeRole:   "$(.params.assumeRole)",
+				Region:       "$(.params.region)",
+				Endpoint:     "$(.params.endpoint)",
+			},
+			Service: "$(.params.service)",
+		},
+	}
+
+	err := ctx.NewStructTemplater(map[string]any{"params": map[string]any{
+		"connection":   "http/main",
+		"username":     "user",
+		"password":     "pass",
+		"url":          "https://example.com/api",
+		"bearer":       "token",
+		"clientID":     "client-id",
+		"clientSecret": "client-secret",
+		"tokenURL":     "https://example.com/oauth/token",
+		"scope":        "scope-a",
+		"audience":     "audience-a",
+		"ca":           "ca-pem",
+		"cert":         "cert-pem",
+		"key":          "key-pem",
+		"contentType":  "application/json",
+		"accessKey":    "access-key",
+		"secretKey":    "secret-key",
+		"sessionToken": "session-token",
+		"assumeRole":   "arn:aws:iam::123456789012:role/example",
+		"region":       "us-east-1",
+		"endpoint":     "https://aws.example.com",
+		"service":      "execute-api",
+	}}, "template", nil).Walk(&conn)
+
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(conn.ConnectionName).To(gomega.Equal("connection://http/main"))
+	g.Expect(conn.GetUsername()).To(gomega.Equal("user"))
+	g.Expect(conn.GetPassword()).To(gomega.Equal("pass"))
+	g.Expect(conn.URL).To(gomega.Equal("https://example.com/api"))
+	g.Expect(conn.Bearer.ValueStatic).To(gomega.Equal("token"))
+	g.Expect(conn.OAuth.ClientID.ValueStatic).To(gomega.Equal("client-id"))
+	g.Expect(conn.OAuth.ClientSecret.ValueStatic).To(gomega.Equal("client-secret"))
+	g.Expect(conn.OAuth.TokenURL).To(gomega.Equal("https://example.com/oauth/token"))
+	g.Expect(conn.OAuth.Scopes).To(gomega.Equal([]string{"scope-a"}))
+	g.Expect(conn.OAuth.Params).To(gomega.Equal(map[string]string{"audience": "audience-a"}))
+	g.Expect(conn.TLS.CA.ValueStatic).To(gomega.Equal("ca-pem"))
+	g.Expect(conn.TLS.Cert.ValueStatic).To(gomega.Equal("cert-pem"))
+	g.Expect(conn.TLS.Key.ValueStatic).To(gomega.Equal("key-pem"))
+	g.Expect(conn.Headers[0].ValueStatic).To(gomega.Equal("application/json"))
+	g.Expect(conn.AWSSigV4.AccessKey.ValueStatic).To(gomega.Equal("access-key"))
+	g.Expect(conn.AWSSigV4.SecretKey.ValueStatic).To(gomega.Equal("secret-key"))
+	g.Expect(conn.AWSSigV4.SessionToken.ValueStatic).To(gomega.Equal("session-token"))
+	g.Expect(conn.AWSSigV4.AssumeRole).To(gomega.Equal("arn:aws:iam::123456789012:role/example"))
+	g.Expect(conn.AWSSigV4.Region).To(gomega.Equal("us-east-1"))
+	g.Expect(conn.AWSSigV4.Endpoint).To(gomega.Equal("https://aws.example.com"))
+	g.Expect(conn.AWSSigV4.Service).To(gomega.Equal("execute-api"))
 }
 
 func TestHTTPConnectionPretty(t *testing.T) {

--- a/types/auth.go
+++ b/types/auth.go
@@ -6,7 +6,7 @@ import (
 
 // +kubebuilder:object:generate=true
 type HTTPBasicAuth struct {
-	Authentication `yaml:",inline" json:",inline"`
+	Authentication `yaml:",inline" json:",inline" template:"true"`
 	NTLM           bool `yaml:"ntlm,omitempty" json:"ntlm,omitempty"`
 	NTLMV2         bool `yaml:"ntlmv2,omitempty" json:"ntlmv2,omitempty"`
 	Digest         bool `yaml:"digest,omitempty" json:"digest,omitempty"`
@@ -14,8 +14,8 @@ type HTTPBasicAuth struct {
 
 // +kubebuilder:object:generate=true
 type Authentication struct {
-	Username EnvVar `yaml:"username,omitempty" json:"username,omitempty"`
-	Password EnvVar `yaml:"password,omitempty" json:"password,omitempty"`
+	Username EnvVar `yaml:"username,omitempty" json:"username,omitempty" template:"true"`
+	Password EnvVar `yaml:"password,omitempty" json:"password,omitempty" template:"true"`
 }
 
 func (auth Authentication) IsEmpty() bool {

--- a/types/oauth.go
+++ b/types/oauth.go
@@ -8,11 +8,11 @@ import (
 
 // +kubebuilder:object:generate=true
 type OAuth struct {
-	ClientID     EnvVar            `json:"clientID,omitempty"`
-	ClientSecret EnvVar            `json:"clientSecret,omitempty"`
-	Scopes       []string          `json:"scope,omitempty" yaml:"scope,omitempty"`
-	TokenURL     string            `json:"tokenURL,omitempty" yaml:"tokenURL,omitempty"`
-	Params       map[string]string `json:"params,omitempty" yaml:"params,omitempty"`
+	ClientID     EnvVar            `json:"clientID,omitempty" template:"true"`
+	ClientSecret EnvVar            `json:"clientSecret,omitempty" template:"true"`
+	Scopes       []string          `json:"scope,omitempty" yaml:"scope,omitempty" template:"true"`
+	TokenURL     string            `json:"tokenURL,omitempty" yaml:"tokenURL,omitempty" template:"true"`
+	Params       map[string]string `json:"params,omitempty" yaml:"params,omitempty" template:"true"`
 }
 
 func (o OAuth) IsEmpty() bool {


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/3218

HTTP playbook actions can template the action itself, but embedded HTTP connection fields were skipped unless the fields also carried template tags.

This left values like `$(.params.url)` unresolved, causing HTTP requests to run against literal relative URLs such as `/$(.params.url)`.

Add template tags across HTTP connection, auth, OAuth, TLS, and AWS SigV4 fields so existing playbook templating handles connection configuration correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS connections now support dynamic values in connection names, credentials, region, and endpoint settings.
  * HTTP connections now support dynamic values in URLs, headers, bearer tokens, and OAuth credentials.
  * Authentication credentials and OAuth configuration now support dynamic variable injection across all connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->