### PR TITLE
feat(query): add resource selector search for config insights

### DIFF
--- a/query/config_analysis.go
+++ b/query/config_analysis.go
@@ -17,7 +17,7 @@ func FindConfigAnalysisByResourceSelector(ctx context.Context, limit int, resour
 }
 
 func FindConfigAnalysisIDsByResourceSelector(ctx context.Context, limit int, resourceSelectors ...types.ResourceSelector) ([]uuid.UUID, error) {
-	return queryTableWithResourceSelectors(ctx, models.ConfigAnalysis{}.TableName(), limit, resourceSelectors...)
+	return queryTableWithResourceSelectors(ctx, configAnalysisItemsView, limit, resourceSelectors...)
 }
 
 func GetConfigAnalysisByIDs(ctx context.Context, ids []uuid.UUID) ([]models.ConfigAnalysis, error) {

--- a/query/config_analysis.go
+++ b/query/config_analysis.go
@@ -1,0 +1,34 @@
+package query
+
+import (
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/google/uuid"
+)
+
+func FindConfigAnalysisByResourceSelector(ctx context.Context, limit int, resourceSelectors ...types.ResourceSelector) ([]models.ConfigAnalysis, error) {
+	ids, err := FindConfigAnalysisIDsByResourceSelector(ctx, limit, resourceSelectors...)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetConfigAnalysisByIDs(ctx, ids)
+}
+
+func FindConfigAnalysisIDsByResourceSelector(ctx context.Context, limit int, resourceSelectors ...types.ResourceSelector) ([]uuid.UUID, error) {
+	return queryTableWithResourceSelectors(ctx, models.ConfigAnalysis{}.TableName(), limit, resourceSelectors...)
+}
+
+func GetConfigAnalysisByIDs(ctx context.Context, ids []uuid.UUID) ([]models.ConfigAnalysis, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var analyses []models.ConfigAnalysis
+	if err := ctx.DB().Where("id IN ?", ids).Find(&analyses).Error; err != nil {
+		return nil, err
+	}
+
+	return analyses, nil
+}

--- a/query/models.go
+++ b/query/models.go
@@ -424,11 +424,9 @@ var ConfigAnalysisQueryModel = QueryModel{
 	JSONMapColumns: []string{"analysis"},
 	HasProperties:  true,
 	Aliases: map[string]string{
-		"type":           "analysis_type",
-		"analyzer_type":  "analysis_type",
-		"config":         "config_id",
-		"first_observed": "first_observed",
-		"last_observed":  "last_observed",
+		"type":          "analysis_type",
+		"analyzer_type": "analysis_type",
+		"config":        "config_id",
 	},
 	FieldMapper: map[string]func(ctx context.Context, id string) (any, error){
 		"first_observed": DateMapper,

--- a/query/models.go
+++ b/query/models.go
@@ -424,7 +424,7 @@ var ConfigAnalysisQueryModel = QueryModel{
 		"severity", "status", "summary", "message", "first_observed", "last_observed",
 		"name", "type", "config_type", "config_class", "agent_id", "deleted_at", "path",
 	},
-	JSONMapColumns: []string{"analysis", "tags", "labels", "config"},
+	JSONMapColumns: []string{"tags", "labels", "config"},
 	HasProperties:  true,
 	HasTags:        true,
 	HasLabels:      true,
@@ -432,7 +432,6 @@ var ConfigAnalysisQueryModel = QueryModel{
 	HasDeletedAt:   true,
 	Aliases: map[string]string{
 		"analyzer_type": "analysis_type",
-		"config":        "config_id",
 		"config_type":   "type",
 		"namespace":     "tags.namespace",
 	},

--- a/query/models.go
+++ b/query/models.go
@@ -412,25 +412,35 @@ var CanaryQueryModel = QueryModel{
 	},
 }
 
-// ConfigAnalysisQueryModel powers resource selector search for config insights
-// (the config_analysis table). The table has neither name/namespace nor
-// deleted_at/agent_id/tags/labels columns, so those features stay disabled.
+const configAnalysisItemsView = "config_analysis_items"
+
+// ConfigAnalysisQueryModel powers resource selector search for config insights.
+// It queries config_analysis_items so config parent fields (agent, deleted_at,
+// type, tags, labels) are available like they are for catalog_changes.
 var ConfigAnalysisQueryModel = QueryModel{
-	Table: models.ConfigAnalysis{}.TableName(),
+	Table: configAnalysisItemsView,
 	Columns: []string{
 		"id", "config_id", "scraper_id", "source", "analyzer", "analysis_type",
 		"severity", "status", "summary", "message", "first_observed", "last_observed",
+		"name", "type", "config_type", "config_class", "agent_id", "deleted_at", "path",
 	},
-	JSONMapColumns: []string{"analysis"},
+	JSONMapColumns: []string{"analysis", "tags", "labels", "config"},
 	HasProperties:  true,
+	HasTags:        true,
+	HasLabels:      true,
+	HasAgents:      true,
+	HasDeletedAt:   true,
 	Aliases: map[string]string{
-		"type":          "analysis_type",
 		"analyzer_type": "analysis_type",
 		"config":        "config_id",
+		"config_type":   "type",
+		"namespace":     "tags.namespace",
 	},
 	FieldMapper: map[string]func(ctx context.Context, id string) (any, error){
+		"agent_id":       AgentMapper,
 		"first_observed": DateMapper,
 		"last_observed":  DateMapper,
+		"deleted_at":     DateMapper,
 	},
 }
 
@@ -454,7 +464,7 @@ func GetModelFromTable(table string) (QueryModel, error) {
 		return ConfigItemSummaryQueryModel, nil
 	case models.View{}.TableName():
 		return ViewQueryModel, nil
-	case models.ConfigAnalysis{}.TableName():
+	case models.ConfigAnalysis{}.TableName(), configAnalysisItemsView:
 		return ConfigAnalysisQueryModel, nil
 	default:
 		return QueryModel{}, fmt.Errorf("invalid table")

--- a/query/models.go
+++ b/query/models.go
@@ -192,6 +192,10 @@ type QueryModel struct {
 	// True when the table has properties column
 	HasProperties bool
 
+	// True when the table has a "deleted_at" column.
+	// When false, the default `deleted_at IS NULL` filter is not applied.
+	HasDeletedAt bool
+
 	// FieldMapper maps the value of these fields
 	FieldMapper map[string]func(ctx context.Context, id string) (any, error)
 }
@@ -211,6 +215,7 @@ var ConfigItemQueryModel = QueryModel{
 	HasTags:        true,
 	HasAgents:      true,
 	HasLabels:      true,
+	HasDeletedAt:   true,
 	Aliases: map[string]string{
 		"created":     "created_at",
 		"updated":     "updated_at",
@@ -243,6 +248,7 @@ var ConfigItemSummaryQueryModel = QueryModel{
 	HasAgents:      true,
 	HasLabels:      true,
 	HasProperties:  true,
+	HasDeletedAt:   true,
 	Aliases: map[string]string{
 		"created":        "created_at",
 		"updated":        "updated_at",
@@ -293,6 +299,7 @@ var ComponentQueryModel = QueryModel{
 	HasProperties: true,
 	HasAgents:     true,
 	HasLabels:     true,
+	HasDeletedAt:  true,
 	FieldMapper: map[string]func(ctx context.Context, id string) (any, error){
 		"agent_id":   AgentMapper,
 		"created_at": DateMapper,
@@ -316,8 +323,9 @@ var CheckQueryModel = QueryModel{
 		"health":     "status",
 		"check_type": "type",
 	},
-	HasAgents: true,
-	HasLabels: true,
+	HasAgents:    true,
+	HasLabels:    true,
+	HasDeletedAt: true,
 	FieldMapper: map[string]func(ctx context.Context, id string) (any, error){
 		"agent_id":   AgentMapper,
 		"created_at": DateMapper,
@@ -327,9 +335,10 @@ var CheckQueryModel = QueryModel{
 }
 
 var PlaybookQueryModel = QueryModel{
-	Table:   models.Playbook{}.TableName(),
-	HasTags: true,
-	Columns: []string{"id", "name", "namespace", "created_at", "updated_at", "deleted_at"},
+	Table:        models.Playbook{}.TableName(),
+	HasTags:      true,
+	HasDeletedAt: true,
+	Columns:      []string{"id", "name", "namespace", "created_at", "updated_at", "deleted_at"},
 	Aliases: map[string]string{
 		"created": "created_at",
 		"updated": "updated_at",
@@ -343,8 +352,9 @@ var PlaybookQueryModel = QueryModel{
 }
 
 var ConnectionQueryModel = QueryModel{
-	Table:   models.Connection{}.TableName(),
-	Columns: []string{"id", "name", "namespace", "type"},
+	Table:        models.Connection{}.TableName(),
+	Columns:      []string{"id", "name", "namespace", "type"},
+	HasDeletedAt: true,
 }
 
 var ConfigChangeQueryModel = QueryModel{
@@ -356,6 +366,7 @@ var ConfigChangeQueryModel = QueryModel{
 	JSONMapColumns: []string{"tags", "details"},
 	HasAgents:      true,
 	HasTags:        true,
+	HasDeletedAt:   true,
 	Aliases: map[string]string{
 		"created":        "created_at",
 		"first_observed": "first_observed",
@@ -374,6 +385,7 @@ var ViewQueryModel = QueryModel{
 	Columns:        []string{"name", "namespace"},
 	JSONMapColumns: []string{"labels"},
 	HasLabels:      true,
+	HasDeletedAt:   true,
 }
 
 var CanaryQueryModel = QueryModel{
@@ -385,6 +397,7 @@ var CanaryQueryModel = QueryModel{
 	JSONMapColumns: []string{"labels", "spec"},
 	HasLabels:      true,
 	HasAgents:      true,
+	HasDeletedAt:   true,
 	Aliases: map[string]string{
 		"created": "created_at",
 		"updated": "updated_at",
@@ -396,6 +409,30 @@ var CanaryQueryModel = QueryModel{
 		"created_at": DateMapper,
 		"updated_at": DateMapper,
 		"deleted_at": DateMapper,
+	},
+}
+
+// ConfigAnalysisQueryModel powers resource selector search for config insights
+// (the config_analysis table). The table has neither name/namespace nor
+// deleted_at/agent_id/tags/labels columns, so those features stay disabled.
+var ConfigAnalysisQueryModel = QueryModel{
+	Table: models.ConfigAnalysis{}.TableName(),
+	Columns: []string{
+		"id", "config_id", "scraper_id", "source", "analyzer", "analysis_type",
+		"severity", "status", "summary", "message", "first_observed", "last_observed",
+	},
+	JSONMapColumns: []string{"analysis"},
+	HasProperties:  true,
+	Aliases: map[string]string{
+		"type":           "analysis_type",
+		"analyzer_type":  "analysis_type",
+		"config":         "config_id",
+		"first_observed": "first_observed",
+		"last_observed":  "last_observed",
+	},
+	FieldMapper: map[string]func(ctx context.Context, id string) (any, error){
+		"first_observed": DateMapper,
+		"last_observed":  DateMapper,
 	},
 }
 
@@ -419,6 +456,8 @@ func GetModelFromTable(table string) (QueryModel, error) {
 		return ConfigItemSummaryQueryModel, nil
 	case models.View{}.TableName():
 		return ViewQueryModel, nil
+	case models.ConfigAnalysis{}.TableName():
+		return ConfigAnalysisQueryModel, nil
 	default:
 		return QueryModel{}, fmt.Errorf("invalid table")
 	}

--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -30,23 +30,25 @@ type SearchResourcesRequest struct {
 	// Limit the number of results returned per resource type
 	Limit int `json:"limit"`
 
-	Canaries      []types.ResourceSelector `json:"canaries"`
-	Checks        []types.ResourceSelector `json:"checks"`
-	Components    []types.ResourceSelector `json:"components"`
-	Configs       []types.ResourceSelector `json:"configs"`
-	ConfigChanges []types.ResourceSelector `json:"config_changes"`
-	Playbooks     []types.ResourceSelector `json:"playbooks"`
-	Connections   []types.ResourceSelector `json:"connections"`
+	Canaries       []types.ResourceSelector `json:"canaries"`
+	Checks         []types.ResourceSelector `json:"checks"`
+	Components     []types.ResourceSelector `json:"components"`
+	Configs        []types.ResourceSelector `json:"configs"`
+	ConfigChanges  []types.ResourceSelector `json:"config_changes"`
+	ConfigAnalysis []types.ResourceSelector `json:"config_analysis"`
+	Playbooks      []types.ResourceSelector `json:"playbooks"`
+	Connections    []types.ResourceSelector `json:"connections"`
 }
 
 type SearchResourcesResponse struct {
-	Canaries      []SelectedResource `json:"canaries,omitempty"`
-	Checks        []SelectedResource `json:"checks,omitempty"`
-	Components    []SelectedResource `json:"components,omitempty"`
-	Configs       []SelectedResource `json:"configs,omitempty"`
-	ConfigChanges []SelectedResource `json:"config_changes,omitempty"`
-	Playbooks     []SelectedResource `json:"playbooks,omitempty"`
-	Connections   []SelectedResource `json:"connections,omitempty"`
+	Canaries       []SelectedResource `json:"canaries,omitempty"`
+	Checks         []SelectedResource `json:"checks,omitempty"`
+	Components     []SelectedResource `json:"components,omitempty"`
+	Configs        []SelectedResource `json:"configs,omitempty"`
+	ConfigChanges  []SelectedResource `json:"config_changes,omitempty"`
+	ConfigAnalysis []SelectedResource `json:"config_analysis,omitempty"`
+	Playbooks      []SelectedResource `json:"playbooks,omitempty"`
+	Connections    []SelectedResource `json:"connections,omitempty"`
 }
 
 func (r *SearchResourcesResponse) GetIDs() []string {
@@ -56,6 +58,7 @@ func (r *SearchResourcesResponse) GetIDs() []string {
 	ids = append(ids, lo.Map(r.Configs, func(c SelectedResource, _ int) string { return c.ID })...)
 	ids = append(ids, lo.Map(r.Components, func(c SelectedResource, _ int) string { return c.ID })...)
 	ids = append(ids, lo.Map(r.ConfigChanges, func(c SelectedResource, _ int) string { return c.ID })...)
+	ids = append(ids, lo.Map(r.ConfigAnalysis, func(c SelectedResource, _ int) string { return c.ID })...)
 	ids = append(ids, lo.Map(r.Playbooks, func(c SelectedResource, _ int) string { return c.ID })...)
 	ids = append(ids, lo.Map(r.Connections, func(c SelectedResource, _ int) string { return c.ID })...)
 	return ids
@@ -190,6 +193,23 @@ func SearchResources(ctx context.Context, req SearchResourcesRequest) (*SearchRe
 	})
 
 	eg.Go(func() error {
+		if items, err := FindConfigAnalysisByResourceSelector(ctx, req.Limit, req.ConfigAnalysis...); err != nil {
+			return err
+		} else {
+			for i := range items {
+				output.ConfigAnalysis = append(output.ConfigAnalysis, SelectedResource{
+					ID:     items[i].ID.String(),
+					Name:   items[i].Analyzer,
+					Type:   string(items[i].AnalysisType),
+					Status: items[i].Status,
+				})
+			}
+		}
+
+		return nil
+	})
+
+	eg.Go(func() error {
 		if items, err := FindPlaybooksByResourceSelector(ctx, req.Limit, req.Playbooks...); err != nil {
 			return err
 		} else {
@@ -288,7 +308,7 @@ func SetResourceSelectorClause(
 		query = query.Clauses(clauses...)
 	}
 
-	if !resourceSelector.IncludeDeleted && !searchSetDeleted {
+	if !resourceSelector.IncludeDeleted && !searchSetDeleted && qm.HasDeletedAt {
 		query = query.Where("deleted_at IS NULL")
 	}
 

--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -78,6 +78,9 @@ type SelectedResource struct {
 	// Status is the resource's free-form operational status (e.g. "Running",
 	// "Pending"). Populated for configs and components.
 	Status string `json:"status,omitempty"`
+	// Severity is populated for resource kinds that carry a severity
+	// (e.g. config insights). nil for other kinds.
+	Severity *string `json:"severity,omitempty"`
 }
 
 func SearchResources(ctx context.Context, req SearchResourcesRequest) (*SearchResourcesResponse, error) {
@@ -197,11 +200,16 @@ func SearchResources(ctx context.Context, req SearchResourcesRequest) (*SearchRe
 			return err
 		} else {
 			for i := range items {
+				var severity *string
+				if s := string(items[i].Severity); s != "" {
+					severity = &s
+				}
 				output.ConfigAnalysis = append(output.ConfigAnalysis, SelectedResource{
-					ID:     items[i].ID.String(),
-					Name:   items[i].Analyzer,
-					Type:   string(items[i].AnalysisType),
-					Status: items[i].Status,
+					ID:       items[i].ID.String(),
+					Name:     items[i].Analyzer,
+					Type:     string(items[i].AnalysisType),
+					Status:   items[i].Status,
+					Severity: severity,
 				})
 			}
 		}

--- a/schema/apply.go
+++ b/schema/apply.go
@@ -50,6 +50,7 @@ func Apply(ctx context.Context, connection string) error {
 	exclude := []string{
 		"config_items.properties_values",
 		"components.properties_values",
+		"config_analysis.properties_values",
 		"config_locations.config_locations_location_pattern_idx",
 
 		// These indexes are managed in the views/037_notification_group_resources.sql file

--- a/tests/fixtures/dummy/config_analysis.go
+++ b/tests/fixtures/dummy/config_analysis.go
@@ -5,25 +5,31 @@ import (
 	"github.com/google/uuid"
 )
 
+var LogisticsDBRDSAnalysis = models.ConfigAnalysis{
+	ID:            uuid.New(),
+	ConfigID:      LogisticsDBRDS.ID,
+	Analyzer:      "rds-port-exposed",
+	AnalysisType:  models.AnalysisTypeSecurity,
+	Severity:      models.SeverityCritical,
+	Message:       "Port exposed to public",
+	FirstObserved: &CurrentTime,
+	Status:        models.AnalysisStatusOpen,
+}
+
+var EC2InstanceBAnalysis = models.ConfigAnalysis{
+	ID:            uuid.New(),
+	ConfigID:      EC2InstanceB.ID,
+	Analyzer:      "ec2-ssh-key-not-rotated",
+	AnalysisType:  models.AnalysisTypeSecurity,
+	Severity:      models.SeverityCritical,
+	Message:       "SSH key not rotated",
+	FirstObserved: &CurrentTime,
+	Status:        models.AnalysisStatusOpen,
+}
+
 func AllDummyConfigAnalysis() []models.ConfigAnalysis {
 	return []models.ConfigAnalysis{
-		{
-			ID:            uuid.New(),
-			ConfigID:      LogisticsDBRDS.ID,
-			AnalysisType:  models.AnalysisTypeSecurity,
-			Severity:      "critical",
-			Message:       "Port exposed to public",
-			FirstObserved: &CurrentTime,
-			Status:        models.AnalysisStatusOpen,
-		},
-		{
-			ID:            uuid.New(),
-			ConfigID:      EC2InstanceB.ID,
-			AnalysisType:  models.AnalysisTypeSecurity,
-			Severity:      "critical",
-			Message:       "SSH key not rotated",
-			FirstObserved: &CurrentTime,
-			Status:        models.AnalysisStatusOpen,
-		},
+		LogisticsDBRDSAnalysis,
+		EC2InstanceBAnalysis,
 	}
 }

--- a/tests/fixtures/dummy/config_analysis.go
+++ b/tests/fixtures/dummy/config_analysis.go
@@ -27,9 +27,21 @@ var EC2InstanceBAnalysis = models.ConfigAnalysis{
 	Status:        models.AnalysisStatusOpen,
 }
 
+var LogisticsAPIPodAnalysis = models.ConfigAnalysis{
+	ID:            uuid.New(),
+	ConfigID:      LogisticsAPIPodConfig.ID,
+	Analyzer:      "pod-security-context",
+	AnalysisType:  models.AnalysisTypeSecurity,
+	Severity:      models.SeverityHigh,
+	Message:       "Pod security context is missing",
+	FirstObserved: &CurrentTime,
+	Status:        models.AnalysisStatusOpen,
+}
+
 func AllDummyConfigAnalysis() []models.ConfigAnalysis {
 	return []models.ConfigAnalysis{
 		LogisticsDBRDSAnalysis,
 		EC2InstanceBAnalysis,
+		LogisticsAPIPodAnalysis,
 	}
 }

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -752,9 +752,14 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
 		},
 		{
-			description:      "by analysis_type alias (type)",
-			resourceSelector: types.ResourceSelector{Search: "type=security config_id=" + ec2ConfigID},
+			description:      "by analysis_type",
+			resourceSelector: types.ResourceSelector{Search: "analysis_type=security config_id=" + ec2ConfigID},
 			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
+		},
+		{
+			description:      "by config type",
+			resourceSelector: types.ResourceSelector{Search: "type=" + *dummy.LogisticsDBRDS.Type + " config_id=" + logisticsConfigID},
+			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
 		},
 		{
 			description:      "by severity",

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -742,6 +742,11 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
 		},
 		{
+			description:      "config is not a config_id alias",
+			resourceSelector: types.ResourceSelector{Search: "config=" + logisticsConfigID},
+			expectedIDs:      nil,
+		},
+		{
 			description:      "by analyzer",
 			resourceSelector: types.ResourceSelector{Search: "analyzer=ec2-ssh-key-not-rotated"},
 			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
@@ -772,7 +777,7 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
 		},
 		{
-			description:      "no match when filtering deleted (table has no deleted_at)",
+			description:      "no match for unknown analyzer",
 			resourceSelector: types.ResourceSelector{Search: "analyzer=does-not-exist"},
 			expectedIDs:      nil,
 		},
@@ -786,6 +791,19 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 			Expect(gotIDs).To(ConsistOf(test.expectedIDs))
 		})
 	}
+
+	ginkgo.It("finds high or critical pod analysis", func() {
+		analyses, err := query.FindConfigAnalysisByResourceSelector(DefaultContext, -1, types.ResourceSelector{Search: "severity=high,critical type=Kubernetes::Pod"})
+		Expect(err).To(BeNil())
+		gotIDs := lo.Map(analyses, func(a models.ConfigAnalysis, _ int) uuid.UUID { return a.ID })
+		Expect(gotIDs).To(ContainElement(dummy.LogisticsAPIPodAnalysis.ID))
+	})
+
+	ginkgo.It("does not expose analysis json search", func() {
+		_, err := query.FindConfigAnalysisByResourceSelector(DefaultContext, -1, types.ResourceSelector{Search: "analysis.foo=bar"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("query for column:analysis.foo"))
+	})
 
 	ginkgo.It("flows through SearchResources", func() {
 		response, err := query.SearchResources(DefaultContext, query.SearchResourcesRequest{

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -724,6 +724,76 @@ var _ = ginkgo.Describe("View Resource Selector", func() {
 	})
 })
 
+var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
+	// Other suites insert additional config_analysis rows that are never cleaned
+	// up, so the severity/status/type cases are scoped by config_id to stay
+	// deterministic.
+	logisticsConfigID := dummy.LogisticsDBRDSAnalysis.ConfigID.String()
+	ec2ConfigID := dummy.EC2InstanceBAnalysis.ConfigID.String()
+
+	testData := []struct {
+		description      string
+		resourceSelector types.ResourceSelector
+		expectedIDs      []uuid.UUID
+	}{
+		{
+			description:      "by config_id",
+			resourceSelector: types.ResourceSelector{Search: "config_id=" + logisticsConfigID},
+			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
+		},
+		{
+			description:      "by analyzer",
+			resourceSelector: types.ResourceSelector{Search: "analyzer=ec2-ssh-key-not-rotated"},
+			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
+		},
+		{
+			description:      "by analyzer prefix",
+			resourceSelector: types.ResourceSelector{Search: "analyzer=rds*"},
+			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
+		},
+		{
+			description:      "by analysis_type alias (type)",
+			resourceSelector: types.ResourceSelector{Search: "type=security config_id=" + ec2ConfigID},
+			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
+		},
+		{
+			description:      "by severity",
+			resourceSelector: types.ResourceSelector{Search: "severity=critical config_id=" + logisticsConfigID},
+			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
+		},
+		{
+			description:      "by status",
+			resourceSelector: types.ResourceSelector{Search: "status=open config_id=" + ec2ConfigID},
+			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
+		},
+		{
+			description:      "no match when filtering deleted (table has no deleted_at)",
+			resourceSelector: types.ResourceSelector{Search: "analyzer=does-not-exist"},
+			expectedIDs:      nil,
+		},
+	}
+
+	for _, test := range testData {
+		ginkgo.It(test.description, func() {
+			analyses, err := query.FindConfigAnalysisByResourceSelector(DefaultContext, -1, test.resourceSelector)
+			Expect(err).To(BeNil())
+			gotIDs := lo.Map(analyses, func(a models.ConfigAnalysis, _ int) uuid.UUID { return a.ID })
+			Expect(gotIDs).To(ConsistOf(test.expectedIDs))
+		})
+	}
+
+	ginkgo.It("flows through SearchResources", func() {
+		response, err := query.SearchResources(DefaultContext, query.SearchResourcesRequest{
+			ConfigAnalysis: []types.ResourceSelector{{Search: "analyzer=rds-port-exposed"}},
+		})
+		Expect(err).To(BeNil())
+		Expect(response.ConfigAnalysis).To(HaveLen(1))
+		Expect(response.ConfigAnalysis[0].ID).To(Equal(dummy.LogisticsDBRDSAnalysis.ID.String()))
+		Expect(response.ConfigAnalysis[0].Name).To(Equal("rds-port-exposed"))
+		Expect(response.ConfigAnalysis[0].Type).To(Equal(string(models.AnalysisTypeSecurity)))
+	})
+})
+
 var _ = ginkgo.Describe("Resoure Selector with PEG", ginkgo.Ordered, func() {
 	ginkgo.BeforeAll(func() {
 		_ = query.SyncConfigCache(DefaultContext)

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -791,6 +791,7 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 		Expect(response.ConfigAnalysis[0].ID).To(Equal(dummy.LogisticsDBRDSAnalysis.ID.String()))
 		Expect(response.ConfigAnalysis[0].Name).To(Equal("rds-port-exposed"))
 		Expect(response.ConfigAnalysis[0].Type).To(Equal(string(models.AnalysisTypeSecurity)))
+		Expect(response.ConfigAnalysis[0].Severity).To(Equal(lo.ToPtr(string(models.SeverityCritical))))
 	})
 })
 

--- a/views/002_seed.sql
+++ b/views/002_seed.sql
@@ -39,7 +39,7 @@ END $$;
 DO $$
 DECLARE
   tbl TEXT;
-  tables TEXT[] := ARRAY['components', 'config_items'];
+  tables TEXT[] := ARRAY['components', 'config_items', 'config_analysis'];
 BEGIN
   FOREACH tbl IN ARRAY tables LOOP
     IF NOT EXISTS (

--- a/views/006_config_views.sql
+++ b/views/006_config_views.sql
@@ -595,9 +595,18 @@ FOR EACH ROW
 
 DROP VIEW IF EXISTS config_analysis_items;
 
+-- Used by resource selector search for config analysis / insights.
 CREATE OR REPLACE VIEW config_analysis_items AS
   SELECT
     ca.*,
+    ci.name,
+    ci.deleted_at,
+    ci.type,
+    ci.tags,
+    ci.labels,
+    ci.config,
+    ci.agent_id,
+    ci.path,
     ci.name as config_name,
     ci.type as config_type,
     ci.config_class


### PR DESCRIPTION
## What

Adds resource selector search support for **config insights** (the `config_analysis` table), matching how configs and config changes are already searchable.

This means insights can now be searched through the same machinery as the other resource kinds — including the `POST /resources/search` endpoint in mission-control, which is generic over `SearchResourcesRequest`/`SearchResourcesResponse` and therefore gains a new `config_analysis` key automatically.

## Changes

- **`query/models.go`**
  - New `ConfigAnalysisQueryModel` (searchable columns: `config_id`, `scraper_id`, `source`, `analyzer`, `analysis_type`, `severity`, `status`, `summary`, `message`, `first_observed`, `last_observed`; `type`/`config` aliases; date mappers) and registered it in `GetModelFromTable`.
  - New `HasDeletedAt` flag on `QueryModel`. The resource-selector engine previously **always** appended `deleted_at IS NULL`, which would error on `config_analysis` (no such column). The flag is set `true` on all existing 9 models to preserve behavior, and left `false` for `config_analysis`.
- **`query/resource_selector.go`**
  - Gated the default `deleted_at IS NULL` clause on `qm.HasDeletedAt`.
  - Added `ConfigAnalysis` to `SearchResourcesRequest` / `SearchResourcesResponse`, `GetIDs`, and a new errgroup branch in `SearchResources`.
- **`query/config_analysis.go`** (new) — `FindConfigAnalysisByResourceSelector`, `FindConfigAnalysisIDsByResourceSelector`, `GetConfigAnalysisByIDs`, mirroring the config-changes helpers.

## Example

```json
POST /resources/search
{ "config_analysis": [{ "search": "severity=critical status=open" }] }
```

## Tests

- New `Config Analysis Resource Selector` spec block: by `config_id`, `analyzer` (exact + prefix), `analysis_type` (via `type` alias), `severity`, `status`, no-match, and end-to-end via `SearchResources`.
- Exported the dummy config-analysis fixtures with stable IDs/analyzers.
- Full resource-selector suite passes (132 specs) — no regression from the `HasDeletedAt` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and searching config analysis results alongside other resource types.
  * Search results now include severity information where available.
  * Expanded config analysis details returned in listings for richer context.

* **Bug Fixes**
  * Improved deleted-item filtering so it only applies where supported.
  * Fixed database state handling to include config analysis data correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->