### PR TITLE
feat(query): populate timestamps for config analysis search

### DIFF
--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -246,6 +246,7 @@ func SearchResources(ctx context.Context, req SearchResourcesRequest) (*SearchRe
 					Status:   items[i].Status,
 					Severity: severity,
 				}
+				req.setTimestamps(&resource, items[i].FirstObserved, items[i].LastObserved, nil)
 				output.ConfigAnalysis = append(output.ConfigAnalysis, resource)
 			}
 		}

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -471,8 +471,9 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 
 		ginkgo.It("populates timestamps when requested", func() {
 			items, err := query.SearchResources(DefaultContext, query.SearchResourcesRequest{
-				Timestamps: true,
-				Configs:    []types.ResourceSelector{{ID: dummy.KubernetesNodeA.ID.String()}},
+				Timestamps:     true,
+				Configs:        []types.ResourceSelector{{ID: dummy.KubernetesNodeA.ID.String()}},
+				ConfigAnalysis: []types.ResourceSelector{{ID: dummy.LogisticsDBRDSAnalysis.ID.String()}},
 			})
 			Expect(err).To(BeNil())
 			Expect(items.Configs).To(HaveLen(1))
@@ -486,15 +487,31 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 			Expect(err).To(BeNil())
 			Expect(string(payload)).To(ContainSubstring("created_at"))
 			Expect(string(payload)).ToNot(ContainSubstring("deleted_at"))
+
+			// config analysis maps first_observed -> created_at and last_observed -> updated_at.
+			Expect(items.ConfigAnalysis).To(HaveLen(1))
+			Expect(items.ConfigAnalysis[0].ID).To(Equal(dummy.LogisticsDBRDSAnalysis.ID.String()))
+			Expect(items.ConfigAnalysis[0].CreatedAt).ToNot(BeNil())
+			Expect(items.ConfigAnalysis[0].UpdatedAt).ToNot(BeNil())
+			// first_observed precedes last_observed, confirming the mapping direction.
+			Expect(*items.ConfigAnalysis[0].CreatedAt).To(BeTemporally("<", *items.ConfigAnalysis[0].UpdatedAt))
+
+			analysisPayload, err := json.Marshal(items.ConfigAnalysis[0])
+			Expect(err).To(BeNil())
+			Expect(string(analysisPayload)).To(ContainSubstring("created_at"))
+			Expect(string(analysisPayload)).To(ContainSubstring("updated_at"))
 		})
 
 		ginkgo.It("omits timestamps by default", func() {
 			items, err := query.SearchResources(DefaultContext, query.SearchResourcesRequest{
-				Configs: []types.ResourceSelector{{ID: dummy.KubernetesNodeA.ID.String()}},
+				Configs:        []types.ResourceSelector{{ID: dummy.KubernetesNodeA.ID.String()}},
+				ConfigAnalysis: []types.ResourceSelector{{ID: dummy.LogisticsDBRDSAnalysis.ID.String()}},
 			})
 			Expect(err).To(BeNil())
 			Expect(items.Configs).To(HaveLen(1))
 			Expect(items.Configs[0].CreatedAt).To(BeNil())
+			Expect(items.ConfigAnalysis).To(HaveLen(1))
+			Expect(items.ConfigAnalysis[0].CreatedAt).To(BeNil())
 
 			payload, err := json.Marshal(items.Configs[0])
 			Expect(err).To(BeNil())

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -470,10 +471,30 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 		}
 
 		ginkgo.It("populates timestamps when requested", func() {
+			// Seed an analysis with explicit first/last observed so the mapping
+			// (first_observed -> created_at, last_observed -> updated_at) is
+			// unambiguous and not reliant on column defaults.
+			firstObserved := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+			lastObserved := time.Date(2025, 6, 7, 8, 9, 10, 0, time.UTC)
+			analysis := models.ConfigAnalysis{
+				ID:            uuid.New(),
+				ConfigID:      dummy.EKSCluster.ID,
+				Analyzer:      "timestamp-mapping",
+				AnalysisType:  models.AnalysisTypeSecurity,
+				Severity:      models.SeverityLow,
+				Status:        models.AnalysisStatusOpen,
+				FirstObserved: &firstObserved,
+				LastObserved:  &lastObserved,
+			}
+			Expect(DefaultContext.DB().Create(&analysis).Error).To(Succeed())
+			ginkgo.DeferCleanup(func() {
+				Expect(DefaultContext.DB().Where("id = ?", analysis.ID).Delete(&models.ConfigAnalysis{}).Error).To(Succeed())
+			})
+
 			items, err := query.SearchResources(DefaultContext, query.SearchResourcesRequest{
 				Timestamps:     true,
 				Configs:        []types.ResourceSelector{{ID: dummy.KubernetesNodeA.ID.String()}},
-				ConfigAnalysis: []types.ResourceSelector{{ID: dummy.LogisticsDBRDSAnalysis.ID.String()}},
+				ConfigAnalysis: []types.ResourceSelector{{ID: analysis.ID.String()}},
 			})
 			Expect(err).To(BeNil())
 			Expect(items.Configs).To(HaveLen(1))
@@ -490,11 +511,11 @@ var _ = ginkgo.Describe("SearchResourceSelectors", func() {
 
 			// config analysis maps first_observed -> created_at and last_observed -> updated_at.
 			Expect(items.ConfigAnalysis).To(HaveLen(1))
-			Expect(items.ConfigAnalysis[0].ID).To(Equal(dummy.LogisticsDBRDSAnalysis.ID.String()))
+			Expect(items.ConfigAnalysis[0].ID).To(Equal(analysis.ID.String()))
 			Expect(items.ConfigAnalysis[0].CreatedAt).ToNot(BeNil())
+			Expect(items.ConfigAnalysis[0].CreatedAt.UTC()).To(Equal(firstObserved))
 			Expect(items.ConfigAnalysis[0].UpdatedAt).ToNot(BeNil())
-			// first_observed precedes last_observed, confirming the mapping direction.
-			Expect(*items.ConfigAnalysis[0].CreatedAt).To(BeTemporally("<", *items.ConfigAnalysis[0].UpdatedAt))
+			Expect(items.ConfigAnalysis[0].UpdatedAt.UTC()).To(Equal(lastObserved))
 
 			analysisPayload, err := json.Marshal(items.ConfigAnalysis[0])
 			Expect(err).To(BeNil())


### PR DESCRIPTION
## Problem

`SearchResources` (`POST /resources/search`) populates `created_at`/`updated_at`/`deleted_at` on the selected resources for every resource kind **except config analysis**. So config insight searches (e.g. `faro catalog insights search`) always came back without timestamps, even when `Timestamps: true` was requested — every other kind (configs, components, checks, changes, playbooks, connections) calls `setTimestamps`, the `config_analysis` branch did not.

## Change

Add the missing `setTimestamps` call in the `config_analysis` branch.

`config_analysis` has no `created_at`/`updated_at` columns — its only timestamps are `first_observed` and `last_observed` — so we map:

- `first_observed` → `created_at`
- `last_observed` → `updated_at`

This keeps the response shape uniform with the other resource kinds.

## Tests

Extended the existing `SearchResourceSelectors` timestamp specs to cover config analysis:
- "populates timestamps when requested" asserts `created_at`/`updated_at` are set and `first_observed < last_observed` (confirming mapping direction).
- "omits timestamps by default" asserts they stay nil when `Timestamps` is not set.

Both pass against the embedded test DB.

## Downstream

Unblocks the `faro catalog insights search` timestamp fix in mission-control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now include timestamps for configuration analysis items when timestamps are requested.
  * Returned timestamps now consistently map to the correct observed time fields in results.
  * Timestamp data remains omitted by default when not requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->