### PR TITLE
fix(query): support agent filter on config analysis resource selector

### DIFF
--- a/query/models.go
+++ b/query/models.go
@@ -431,6 +431,7 @@ var ConfigAnalysisQueryModel = QueryModel{
 	HasAgents:      true,
 	HasDeletedAt:   true,
 	Aliases: map[string]string{
+		"agent":         "agent_id",
 		"analyzer_type": "analysis_type",
 		"config_type":   "type",
 		"namespace":     "tags.namespace",

--- a/tests/query_resource_selector_test.go
+++ b/tests/query_resource_selector_test.go
@@ -810,6 +810,13 @@ var _ = ginkgo.Describe("Config Analysis Resource Selector", func() {
 			expectedIDs:      []uuid.UUID{dummy.EC2InstanceBAnalysis.ID},
 		},
 		{
+			// Agent is folded into the search PEG as agent="all"; without the
+			// agent->agent_id alias on the query model this errored at runtime.
+			description:      "agent=all is a no-op filter",
+			resourceSelector: types.ResourceSelector{Agent: "all", Search: "config_id=" + logisticsConfigID},
+			expectedIDs:      []uuid.UUID{dummy.LogisticsDBRDSAnalysis.ID},
+		},
+		{
 			description:      "no match for unknown analyzer",
 			resourceSelector: types.ResourceSelector{Search: "analyzer=does-not-exist"},
 			expectedIDs:      nil,


### PR DESCRIPTION
## Problem

Searching config insights (`config_analysis`) with an agent set fails at runtime:

```
error applying query model: query for column:agent in table:config_analysis_items not supported
```

`ConfigAnalysisQueryModel` was the **only** agent-bearing query model missing the `"agent": "agent_id"` alias (ConfigItem/Component/Check/Canary all have it). Since `ResourceSelector.Agent` is folded into the search PEG as `agent="all"`, `qm.Apply` tries to resolve a non-existent `agent` column and errors.

This surfaced from `faro catalog insights search` in mission-control, whose `--agent` flag defaults to `all` (mirroring `catalog search`).

## Fix

Add `"agent": "agent_id"` to `ConfigAnalysisQueryModel.Aliases`. The `agent_id` column is already:
- declared in the model's `Columns`,
- wired to `AgentMapper` (which maps `all → nil`, i.e. no-op filter), and
- exposed by the `config_analysis_items` view (`ci.agent_id` from the joined parent config).

So the PEG `agent` field now resolves correctly, exactly like the sibling models. `agent=all` stays a no-op (returns all agents); a specific agent filters by the parent config's agent.

## Test

Added a regression case to the `Config Analysis Resource Selector` suite reproducing the exact path (`Agent: "all"` + a `Search` clause). Verified the emitted SQL drops the agent clause entirely:

```sql
SELECT id FROM "config_analysis_items" WHERE LOWER(CAST("config_id" AS TEXT)) = '...' AND deleted_at IS NULL
```

`ginkgo --focus "Config Analysis Resource Selector" ./tests/` → 13/13 pass.