### PR TITLE
chore: add person_touchpoints schema

### DIFF
--- a/rbac/objects.go
+++ b/rbac/objects.go
@@ -141,6 +141,7 @@ var dbResourceObjMap = map[string]string{
 	"notification_silences":                     policy.ObjectNotification,
 	"people_roles":                              policy.ObjectDatabasePublic,
 	"people":                                    policy.ObjectPeople,
+	"person_touchpoints":                        policy.ObjectPeople,
 	"playbook_action_agent_data":                policy.ObjectPlaybooks,
 	"playbook_approvals":                        policy.ObjectPlaybooks,
 	"playbook_names":                            policy.ObjectDatabasePublic,

--- a/rbac/objects.go
+++ b/rbac/objects.go
@@ -141,7 +141,7 @@ var dbResourceObjMap = map[string]string{
 	"notification_silences":                     policy.ObjectNotification,
 	"people_roles":                              policy.ObjectDatabasePublic,
 	"people":                                    policy.ObjectPeople,
-	"person_touchpoints":                        policy.ObjectPeople,
+	"person_analytics":                          policy.ObjectPeople,
 	"playbook_action_agent_data":                policy.ObjectPlaybooks,
 	"playbook_approvals":                        policy.ObjectPlaybooks,
 	"playbook_names":                            policy.ObjectDatabasePublic,

--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -267,6 +267,7 @@ table "saved_query" {
 }
 
 table "person_touchpoints" {
+  schema = schema.public
   column "person_id" {
     null = false
     type = uuid

--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -98,8 +98,8 @@ table "team_members" {
     type = uuid
   }
   column "source" {
-    type = text
-    null = false
+    type    = text
+    null    = false
     default = "UI"
   }
   primary_key {
@@ -166,7 +166,7 @@ table "teams" {
   primary_key {
     columns = [column.id]
   }
- index "team_name_key" {
+  index "team_name_key" {
     unique  = true
     columns = [column.name]
     where   = "deleted_at IS NULL"
@@ -263,5 +263,32 @@ table "saved_query" {
   }
   primary_key {
     columns = [column.id]
+  }
+}
+
+table "person_touchpoints" {
+  column "person_id" {
+    null = false
+    type = uuid
+  }
+  column "key" {
+    null = false
+    type = text
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.person_id, column.key]
+  }
+
+  foreign_key "person_touchpoints_person_id_fkey" {
+    columns     = [column.person_id]
+    ref_columns = [table.people.column.id]
+    on_update   = CASCADE
+    on_delete   = CASCADE
   }
 }

--- a/schema/teams.hcl
+++ b/schema/teams.hcl
@@ -266,7 +266,7 @@ table "saved_query" {
   }
 }
 
-table "person_touchpoints" {
+table "person_analytics" {
   schema = schema.public
   column "person_id" {
     null = false
@@ -281,12 +281,22 @@ table "person_touchpoints" {
     type    = timestamptz
     default = sql("now()")
   }
+  column "updated_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("now()")
+  }
+  column "count" {
+    null    = false
+    type    = integer
+    default = 1
+  }
 
   primary_key {
     columns = [column.person_id, column.key]
   }
 
-  foreign_key "person_touchpoints_person_id_fkey" {
+  foreign_key "person_analytics_person_id_fkey" {
     columns     = [column.person_id]
     ref_columns = [table.people.column.id]
     on_update   = CASCADE

--- a/tests/triggers_test.go
+++ b/tests/triggers_test.go
@@ -1,12 +1,15 @@
 package tests
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 
 	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/tests/fixtures/dummy"
 	"github.com/flanksource/duty/types"
 )
 
@@ -68,6 +71,45 @@ var _ = ginkgo.Describe("Config Health Triggers", ginkgo.Ordered, func() {
 		err = DefaultContext.DB().Where("event_id = ? AND name = ?", ci.ID.String(), "config.warning").Find(&events).Error
 		Expect(err).ToNot(HaveOccurred())
 		Expect(events).To(HaveLen(1))
+	})
+})
+
+var _ = ginkgo.Describe("Person Analytics Triggers", ginkgo.Ordered, func() {
+	const analyticsKey = "health.open-check"
+
+	ginkgo.AfterAll(func() {
+		err := DefaultContext.DB().Exec(`DELETE FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, analyticsKey).Error
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	ginkgo.It("should increment count and updated_at on duplicate inserts", func() {
+		err := DefaultContext.DB().Exec(`DELETE FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, analyticsKey).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		err = DefaultContext.DB().Exec(`INSERT INTO person_analytics (person_id, "key") VALUES (?, ?)`, dummy.JohnDoe.ID, analyticsKey).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		var first struct {
+			Count     int
+			UpdatedAt time.Time
+		}
+		err = DefaultContext.DB().Raw(`SELECT "count", updated_at FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, analyticsKey).Scan(&first).Error
+		Expect(err).ToNot(HaveOccurred())
+		Expect(first.Count).To(Equal(1))
+
+		time.Sleep(10 * time.Millisecond)
+
+		err = DefaultContext.DB().Exec(`INSERT INTO person_analytics (person_id, "key") VALUES (?, ?)`, dummy.JohnDoe.ID, analyticsKey).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		var second struct {
+			Count     int
+			UpdatedAt time.Time
+		}
+		err = DefaultContext.DB().Raw(`SELECT "count", updated_at FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, analyticsKey).Scan(&second).Error
+		Expect(err).ToNot(HaveOccurred())
+		Expect(second.Count).To(Equal(2))
+		Expect(second.UpdatedAt).To(BeTemporally(">", first.UpdatedAt))
 	})
 })
 

--- a/tests/triggers_test.go
+++ b/tests/triggers_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -76,9 +77,10 @@ var _ = ginkgo.Describe("Config Health Triggers", ginkgo.Ordered, func() {
 
 var _ = ginkgo.Describe("Person Analytics Triggers", ginkgo.Ordered, func() {
 	const analyticsKey = "health.open-check"
+	const concurrentAnalyticsKey = "health.run-now"
 
 	ginkgo.AfterAll(func() {
-		err := DefaultContext.DB().Exec(`DELETE FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, analyticsKey).Error
+		err := DefaultContext.DB().Exec(`DELETE FROM person_analytics WHERE person_id = ? AND "key" IN ?`, dummy.JohnDoe.ID, []string{analyticsKey, concurrentAnalyticsKey}).Error
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -110,6 +112,38 @@ var _ = ginkgo.Describe("Person Analytics Triggers", ginkgo.Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(second.Count).To(Equal(2))
 		Expect(second.UpdatedAt).To(BeTemporally(">", first.UpdatedAt))
+	})
+
+	ginkgo.It("should handle concurrent first inserts", func() {
+		err := DefaultContext.DB().Exec(`DELETE FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, concurrentAnalyticsKey).Error
+		Expect(err).ToNot(HaveOccurred())
+
+		const insertCount = 10
+		start := make(chan struct{})
+		errs := make(chan error, insertCount)
+		var wg sync.WaitGroup
+
+		for range insertCount {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs <- DefaultContext.DB().Exec(`INSERT INTO person_analytics (person_id, "key") VALUES (?, ?)`, dummy.JohnDoe.ID, concurrentAnalyticsKey).Error
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		var count int
+		err = DefaultContext.DB().Raw(`SELECT "count" FROM person_analytics WHERE person_id = ? AND "key" = ?`, dummy.JohnDoe.ID, concurrentAnalyticsKey).Scan(&count).Error
+		Expect(err).ToNot(HaveOccurred())
+		Expect(count).To(Equal(insertCount))
 	})
 })
 

--- a/views/020_teams_triggers.sql
+++ b/views/020_teams_triggers.sql
@@ -17,3 +17,27 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER team_updates
 AFTER UPDATE ON teams
 FOR EACH ROW EXECUTE PROCEDURE handle_team_updates();
+
+CREATE OR REPLACE FUNCTION handle_person_analytics_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE person_analytics
+  SET
+    updated_at = clock_timestamp(),
+    count = count + 1
+  WHERE person_id = NEW.person_id
+    AND key = NEW.key;
+
+  IF FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  NEW.updated_at = COALESCE(NEW.updated_at, clock_timestamp());
+  NEW.count = COALESCE(NEW.count, 1);
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER person_analytics_insert
+BEFORE INSERT ON person_analytics
+FOR EACH ROW EXECUTE PROCEDURE handle_person_analytics_insert();

--- a/views/020_teams_triggers.sql
+++ b/views/020_teams_triggers.sql
@@ -21,6 +21,8 @@ FOR EACH ROW EXECUTE PROCEDURE handle_team_updates();
 CREATE OR REPLACE FUNCTION handle_person_analytics_insert()
 RETURNS TRIGGER AS $$
 BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(NEW.person_id::text || ':' || NEW.key, 0));
+
   UPDATE person_analytics
   SET
     updated_at = clock_timestamp(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new person analytics table to store per-person keyed metrics with timestamps and an auto-incrementing count.
  * Added database trigger behavior to safely maintain these records, including when multiple inserts target the same person/key.
  * Expanded permission resource mapping to include person analytics records.

* **Bug Fixes**
  * Repeated inserts for the same person/key now reliably increment count and update the last-updated timestamp.
  * Concurrent inserts are now handled safely to prevent inconsistent counts.

* **Tests**
  * Added coverage for duplicate inserts and concurrent insert scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->