### PR TITLE
fix: kubernetes connection cache collision

### DIFF
--- a/connection/kubernetes.go
+++ b/connection/kubernetes.go
@@ -128,13 +128,19 @@ func (c KubernetesConnection) String() string {
 
 }
 
-// Hash returns a unique identifier of a KubernetesConnection, suitable for caching
-func (c KubernetesConnection) Hash() string {
+// Hash returns a stable identifier for this Kubernetes connection, suitable for caching.
+func (c KubernetesConnection) Hash(namespace string) string {
 	if c.ConnectionName != "" {
 		return "connection=" + c.ConnectionName
 	}
 	if c.Kubeconfig != nil {
-		return "kubeconfig=" + c.Kubeconfig.String()
+		hash := "kubeconfig=" + c.Kubeconfig.String()
+		if c.Kubeconfig.ValueFrom != nil && !c.Kubeconfig.ValueFrom.IsEmpty() {
+			// Kubeconfig valueFrom refs are namespace-relative, so identical refs in
+			// different namespaces must not share a cached Kubernetes client.
+			return fmt.Sprintf("%s;namespace=%s", hash, namespace)
+		}
+		return hash
 	}
 	if c.EKS != nil {
 		return fmt.Sprintf("eks=%s/%v", c.EKS.Cluster, c.EKS.ToModel())
@@ -163,7 +169,7 @@ func (t KubernetesConnection) ToModel() models.Connection {
 }
 
 func (t KubernetesConnection) Populate(ctx context.Context, freshToken bool, opts ...types.ClientOption) (kubernetes.Interface, *rest.Config, error) {
-	ctx.Counter("kubernetes_connection_populated", "connection", t.Hash()).Add(1)
+	ctx.Counter("kubernetes_connection_populated", "connection", t.Hash(ctx.GetNamespace())).Add(1)
 
 	if clientset, restConfig, err := t.KubeconfigConnection.Populate(ctx, opts...); err != nil {
 		return nil, nil, fmt.Errorf("failed to populate kube config connection: %w", err)

--- a/context/context.go
+++ b/context/context.go
@@ -307,7 +307,7 @@ func (k Context) WithDebug() Context {
 
 type KubernetesConnection interface {
 	Populate(Context, bool, ...types.ClientOption) (kubernetes.Interface, *rest.Config, error)
-	Hash() string
+	Hash(namespace string) string
 	CanExpire() bool
 	String() string
 }
@@ -478,7 +478,7 @@ func (k Context) Kubernetes() (*dutyKubernetes.Client, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("kubernetes connection not set")
 	}
-	connHash := conn.Hash()
+	connHash := conn.Hash(k.GetNamespace())
 	if client, err := k8sclientcache.Get(k, connHash); err == nil {
 		k.Counter("context_kubernetes_client_cache_hit", "connection", connHash).Add(1)
 		if _, err := client.Refresh(k); err != nil {

--- a/context/kuberetes_client.go
+++ b/context/kuberetes_client.go
@@ -33,6 +33,7 @@ func authProvider(clusterAddress string, config map[string]string, persister res
 }
 
 func NewKubernetesClient(ctx Context, conn KubernetesConnection) (*KubernetesClient, error) {
+	connHash := conn.Hash(ctx.GetNamespace())
 	c, rc, err := conn.Populate(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing kubernetes client: %w", err)
@@ -52,8 +53,6 @@ func NewKubernetesClient(ctx Context, conn KubernetesConnection) (*KubernetesCli
 
 	// When BearerTokenFile is set, client-go already performs periodic token reloads from disk.
 	if rc.ExecProvider == nil && rc.AuthProvider == nil && rc.BearerToken != "" && rc.BearerTokenFile == "" {
-		connHash := conn.Hash()
-
 		refreshCallback := func() (*rest.Config, error) {
 			ctx.Counter("kubernetes_auth_plugin_refreshed", "connection", connHash).Add(1)
 			rc, err := client.Refresh(ctx)
@@ -65,7 +64,7 @@ func NewKubernetesClient(ctx Context, conn KubernetesConnection) (*KubernetesCli
 		}
 		rc.AuthProvider = &clientcmdapi.AuthProviderConfig{
 			Name:   "duty",
-			Config: map[string]string{"conn": conn.Hash()},
+			Config: map[string]string{"conn": connHash},
 		}
 	}
 

--- a/context/kubernetes_client_test.go
+++ b/context/kubernetes_client_test.go
@@ -1,0 +1,225 @@
+package context_test
+
+import (
+	stdcontext "context"
+	"encoding/base64"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/duty/connection"
+	dutycontext "github.com/flanksource/duty/context"
+	dutykubernetes "github.com/flanksource/duty/kubernetes"
+	"github.com/flanksource/duty/pkg/kube/auth"
+	"github.com/flanksource/duty/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+// Use unique secret names because the Kubernetes client and env var caches are package globals.
+var kubernetesConnectionCacheCollisionTestID atomic.Uint64
+
+func TestKubernetesConnectionCacheCollision(t *testing.T) {
+	t.Run("basic auth", func(t *testing.T) {
+		providerClient, consumerClient := runKubernetesConnectionCacheCollisionTest(
+			t,
+			uniqueKubeconfigSecretName("basic-auth"),
+			basicAuthKubeconfig("provider", providerHost),
+			basicAuthKubeconfig("consumer", consumerHost),
+		)
+
+		assertDistinctKubernetesClients(t, providerClient, consumerClient)
+	})
+
+	t.Run("bearer token", func(t *testing.T) {
+		providerToken := jwtToken("provider")
+		consumerToken := jwtToken("consumer")
+
+		providerClient, consumerClient := runKubernetesConnectionCacheCollisionTest(
+			t,
+			uniqueKubeconfigSecretName("bearer-token"),
+			bearerTokenKubeconfig("provider", providerHost, providerToken),
+			bearerTokenKubeconfig("consumer", consumerHost, consumerToken),
+		)
+
+		assertDistinctKubernetesClients(t, providerClient, consumerClient)
+		assertAuthCallbackToken(t, providerClient, providerToken)
+		assertAuthCallbackToken(t, consumerClient, consumerToken)
+	})
+}
+
+const (
+	secretKey    = "config"
+	providerNS   = "provider"
+	consumerNS   = "consumer"
+	providerHost = "https://provider.example.invalid"
+	consumerHost = "https://consumer.example.invalid"
+)
+
+func runKubernetesConnectionCacheCollisionTest(t *testing.T, secretName, providerConfig, consumerConfig string) (*dutykubernetes.Client, *dutykubernetes.Client) {
+	t.Helper()
+	resetKubernetesClientTestState(t)
+	t.Cleanup(func() {
+		resetKubernetesClientTestState(t)
+	})
+
+	local := dutykubernetes.NewKubeClient(
+		logger.GetLogger("test"),
+		fake.NewSimpleClientset(
+			kubeconfigSecret(providerNS, secretName, secretKey, providerConfig),
+			kubeconfigSecret(consumerNS, secretName, secretKey, consumerConfig),
+		),
+		&rest.Config{},
+	)
+
+	base := dutycontext.New().WithLocalKubernetes(local)
+
+	providerClient, err := base.
+		WithNamespace(providerNS).
+		WithKubernetes(kubeconfigSecretRefConnection(secretName, secretKey)).
+		Kubernetes()
+	if err != nil {
+		t.Fatalf("provider Kubernetes(): %v", err)
+	}
+	consumerClient, err := base.
+		WithNamespace(consumerNS).
+		WithKubernetes(kubeconfigSecretRefConnection(secretName, secretKey)).
+		Kubernetes()
+	if err != nil {
+		t.Fatalf("consumer Kubernetes(): %v", err)
+	}
+	return providerClient, consumerClient
+}
+
+func assertDistinctKubernetesClients(t *testing.T, providerClient, consumerClient *dutykubernetes.Client) {
+	t.Helper()
+	if providerClient == consumerClient {
+		t.Fatalf("provider and consumer reused the same Kubernetes client")
+	}
+	if got := providerClient.RestConfig().Host; got != providerHost {
+		t.Fatalf("provider host: got %q, want %q", got, providerHost)
+	}
+	if got := consumerClient.RestConfig().Host; got != consumerHost {
+		t.Fatalf("consumer host: got %q, want %q", got, consumerHost)
+	}
+}
+
+func assertAuthCallbackToken(t *testing.T, client *dutykubernetes.Client, want string) {
+	t.Helper()
+
+	restConfig := client.RestConfig()
+	if restConfig.AuthProvider == nil {
+		t.Fatalf("expected rest config to use duty auth provider")
+	}
+
+	callbackKey := restConfig.AuthProvider.Config["conn"]
+	if callbackKey == "" {
+		t.Fatalf("expected duty auth provider conn key")
+	}
+
+	callback, err := auth.AuthKubernetesCallbackCache.Get(stdcontext.Background(), callbackKey)
+	if err != nil {
+		t.Fatalf("get auth callback %q: %v", callbackKey, err)
+	}
+
+	refreshed, err := callback()
+	if err != nil {
+		t.Fatalf("refresh auth callback %q: %v", callbackKey, err)
+	}
+	if got := refreshed.BearerToken; got != want {
+		t.Fatalf("auth callback token: got %q, want %q", got, want)
+	}
+}
+
+func resetKubernetesClientTestState(t *testing.T) {
+	t.Helper()
+
+	dutycontext.New().WithLocalKubernetes(nil)
+	if err := auth.AuthKubernetesCallbackCache.Clear(stdcontext.Background()); err != nil {
+		t.Fatalf("clear auth callback cache: %v", err)
+	}
+}
+
+func uniqueKubeconfigSecretName(prefix string) string {
+	return fmt.Sprintf("config-%s-%d", prefix, kubernetesConnectionCacheCollisionTestID.Add(1))
+}
+
+func kubeconfigSecretRefConnection(secretName, secretKey string) connection.KubernetesConnection {
+	return connection.KubernetesConnection{
+		KubeconfigConnection: connection.KubeconfigConnection{
+			Kubeconfig: &types.EnvVar{
+				ValueFrom: &types.EnvVarSource{
+					SecretKeyRef: &types.SecretKeySelector{
+						LocalObjectReference: types.LocalObjectReference{Name: secretName},
+						Key:                  secretKey,
+					},
+				},
+			},
+		},
+	}
+}
+
+func kubeconfigSecret(namespace, name, key, value string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string][]byte{
+			key: []byte(value),
+		},
+	}
+}
+
+func basicAuthKubeconfig(name, server string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: %s
+  cluster:
+    server: %s
+    insecure-skip-tls-verify: true
+users:
+- name: %s
+  user:
+    username: %s
+    password: password
+contexts:
+- name: %s
+  context:
+    cluster: %s
+    user: %s
+current-context: %s
+`, name, server, name, name, name, name, name, name)
+}
+
+func bearerTokenKubeconfig(name, server, token string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: %s
+  cluster:
+    server: %s
+    insecure-skip-tls-verify: true
+users:
+- name: %s
+  user:
+    token: %q
+contexts:
+- name: %s
+  context:
+    cluster: %s
+    user: %s
+current-context: %s
+`, name, server, name, token, name, name, name, name)
+}
+
+func jwtToken(subject string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":%q,"exp":%d}`, subject, time.Now().Add(time.Hour).Unix())))
+	return header + "." + payload + "."
+}


### PR DESCRIPTION
related: https://github.com/flanksource/canary-checker/issues/3008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes client caching so connections are now scoped by namespace, reducing the chance of reusing the wrong client across different namespaces.
  * Updated Kubernetes auth/token handling to keep cache entries aligned with the current namespace, helping ensure the correct credentials are used.
  * Added test coverage for cache isolation across different Kubernetes connection types and credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->