### PR TITLE
fix(query): cap SearchResources limit at 1000 

### DIFF
--- a/query/resource_selector.go
+++ b/query/resource_selector.go
@@ -108,9 +108,14 @@ func nonZeroTime(t *time.Time) *time.Time {
 	return t
 }
 
+const MaxSearchResourcesLimit = 1000
+
 func SearchResources(ctx context.Context, req SearchResourcesRequest) (*SearchResourcesResponse, error) {
 	var output SearchResourcesResponse
 
+	if req.Limit > MaxSearchResourcesLimit {
+		return nil, api.Errorf(api.EINVALID, "limit %d exceeds the maximum allowed value of %d", req.Limit, MaxSearchResourcesLimit)
+	}
 	if req.Limit <= 0 {
 		req.Limit = 100
 	}


### PR DESCRIPTION
The `POST /resources/search` endpoint (used by `faro catalog ... search`, MCP tools, and the web UI) accepted an unbounded `limit` parameter and only defaulted to 100 when the value was zero or negative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a maximum allowed limit for resource searches to prevent overly large requests.
  * Requests above the supported limit now return a clear validation error, while default behavior for missing or invalid limits remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->