### PR TITLE
chore: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # duty
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/flanksource/duty/badge)](https://securityscorecards.dev/viewer/?uri=github.com/flanksource/duty)
+
 Duty (**D**atabase **Ut**ilit**y**) is a home for common database tools, models and helpers used within the mission control suite of projects.
 
 Duty wraps the awesome [atlas](https://github.com/ariga/atlas/) library, and copies some of its code to make use of internal functions.


### PR DESCRIPTION
Adds the OpenSSF Scorecard badge to the README so the repository’s public security scorecard is visible from the project page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an OpenSSF Scorecard badge to the top of the README for quick access to the project’s scorecard view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->