### PR TITLE
fix: reduce workflow token permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,14 +5,15 @@ name: Benchmark
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   bench:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     name: Benchmark (${{ matrix.title }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -3,12 +3,12 @@ on:
   pull_request:
 permissions:
   contents: read
-  checks: write
-  issues: write
-  pull-requests: write
 jobs:
   gavel:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 50
     services:
       postgres:
@@ -82,4 +82,3 @@ jobs:
             --test-timeout=10m
             --diagnostics
           fail-on-error: "true"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,14 @@ on:
     branches:
       - main
 
-permissions: {} # start with no permission
+permissions: {}
 
 jobs:
   create-release:
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    uses: flanksource/action-workflows/.github/workflows/create-release.yml@a7df3dcb783c34338e46318364e99c0ada62bcd9
+    permissions: {}
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@deae42f62bd50853f206635b574189e0b5f99124
+    secrets:
+      token: ${{ secrets.FLANKBOT }}
 
   bump-clients:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Scorecard flagged workflow `GITHUB_TOKEN` permissions as excessive.

Release creation now uses the updated shared `action-workflows` reusable workflow with an explicit `FLANKBOT` token while leaving the ambient `GITHUB_TOKEN` with no permissions. Benchmark and Gavel write scopes are also moved from workflow-level defaults to the specific jobs that need PR feedback permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to use tighter, job-specific access.
  * Reduced unnecessary write access in release automation and comment-related jobs.
  * Refreshed one workflow reference to a newer pinned version for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->