### PR TITLE
chore: remove archived apm-hub from release bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     if: needs.create-release.outputs.published == 'true'
     strategy:
       matrix:
-        repos: ['mission-control', 'canary-checker', 'config-db', 'apm-hub', 'kopper']
+        repos: ['mission-control', 'canary-checker', 'config-db', 'kopper']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
The release workflow opens dependency bump PRs across downstream repos.

apm-hub is now archived, so release runs should no longer try to checkout and update it. Remove apm-hub from the bump-clients matrix while keeping the active repos unchanged.